### PR TITLE
Allow $this object type comparison

### DIFF
--- a/src/voku/PHPStan/Rules/IfConditionHelper.php
+++ b/src/voku/PHPStan/Rules/IfConditionHelper.php
@@ -201,7 +201,11 @@ final class IfConditionHelper
             &&
             $type_2 instanceof \PHPStan\Type\Type
             &&
-            !$type_2 instanceof \PHPStan\Type\ObjectType
+            !(
+                $type_2 instanceof \PHPStan\Type\ObjectType
+                ||
+                $type_2 instanceof \PHPStan\Type\ThisType
+            )
         ) {
             $errors[] = \PHPStan\Rules\RuleErrorBuilder::message('Do not compare objects directly.')->line($cond->getAttribute('startLine'))->build();
         }

--- a/tests/fixtures/IfConditionsFixtures.php
+++ b/tests/fixtures/IfConditionsFixtures.php
@@ -55,3 +55,14 @@ if ('2032-03-04' >= new \DateTimeImmutable()) {
 if ('2032-03-04' == new \DateTimeImmutable()) {
   // ...
 }
+
+class A1
+{
+    public function foo(self $bar)
+    {
+        // Allow this and static comparison
+        if ($bar === $this) {
+            //
+        }
+    }
+}


### PR DESCRIPTION
As logically is an `ObjectType`, but typed differently in `\PHPStan\Type` namespace