### PR TITLE
Always allow strict comparisons and Coalesce, forbid everything else

### DIFF
--- a/src/voku/PHPStan/Rules/IfConditionHelper.php
+++ b/src/voku/PHPStan/Rules/IfConditionHelper.php
@@ -7,6 +7,7 @@ namespace voku\PHPStan\Rules;
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Type\Enum\EnumCaseObjectType;
+use PHPStan\Type\VerbosityLevel;
 
 final class IfConditionHelper
 {
@@ -218,7 +219,10 @@ final class IfConditionHelper
             return;
         }
 
-        $errors[] = \PHPStan\Rules\RuleErrorBuilder::message('Do not compare objects directly.')->line($cond->getAttribute('startLine'))->build();
+        $errors[] = \PHPStan\Rules\RuleErrorBuilder::message(sprintf(
+            'Do not compare objects directly, %s found.',
+            $type_1->describe(VerbosityLevel::value())
+        ))->line($cond->getAttribute('startLine'))->build();
     }
 
     /**

--- a/src/voku/PHPStan/Rules/IfConditionHelper.php
+++ b/src/voku/PHPStan/Rules/IfConditionHelper.php
@@ -219,6 +219,14 @@ final class IfConditionHelper
             return;
         }
 
+        if (
+            self::isDateTime($type_1)
+            &&
+            self::isDateTime($type_2)
+        ) {
+            return;
+        }
+
         $errors[] = \PHPStan\Rules\RuleErrorBuilder::message(sprintf(
             'Do not compare objects directly, %s found.',
             $type_1->describe(VerbosityLevel::value())
@@ -316,5 +324,14 @@ final class IfConditionHelper
         }
 
         return $return;
+    }
+
+    private static function isDateTime(?\PHPStan\Type\Type $type): bool
+    {
+        return (
+            $type instanceof \PHPStan\Type\ObjectType
+            &&
+            $type->isInstanceOf(\DateTimeInterface::class)->yes()
+        );
     }
 }

--- a/src/voku/PHPStan/Rules/IfConditionHelper.php
+++ b/src/voku/PHPStan/Rules/IfConditionHelper.php
@@ -10,17 +10,20 @@ use PHPStan\Analyser\Scope;
 final class IfConditionHelper
 {
     /**
+     * @param \PHPStan\Type\Type|null $type_1
+     * @param \PHPStan\Type\Type|null $type_2
      * @param \PhpParser\Node $cond
      * @param array<int, \PHPStan\Rules\RuleError> $errors
      * @param array<int, class-string> $classesNotInIfConditions
      *
      * @return array<int, \PHPStan\Rules\RuleError>
+     * @throws \PHPStan\ShouldNotHappenException
      */
     public static function processNodeHelper(
         ?\PHPStan\Type\Type $type_1,
         ?\PHPStan\Type\Type $type_2,
-        Node $cond, 
-        array $errors, 
+        Node $cond,
+        array $errors,
         array $classesNotInIfConditions
     ): array
     {
@@ -28,188 +31,259 @@ final class IfConditionHelper
         // DEBUG
         //var_dump(get_class($type_1), get_class($cond), get_class($type_2));
 
-        if ($cond instanceof \PhpParser\Node\Expr\BinaryOp\NotEqual) {
-
-            if (
-                $type_1 instanceof \PHPStan\Type\Constant\ConstantStringType 
-                &&
-                $type_1->getValue() === '' 
-                &&
-                $type_2 instanceof \PHPStan\Type\StringType
-            ) {
-                $errors[] = \PHPStan\Rules\RuleErrorBuilder::message('Please do not use double negative string conditions. e.g. `(string)$foo != \'\'` is the same as `(string)$foo`.')->line($cond->getAttribute('startLine'))->build();
-            }
-
-            if (
-                (
-                    ($type_1 instanceof \PHPStan\Type\Constant\ConstantStringType && $type_1->getValue() === '') 
-                    ||
-                    ($type_1 instanceof \PHPStan\Type\Constant\ConstantIntegerType && $type_1->getValue() === 0) 
-                    ||
-                    ($type_1 instanceof \PHPStan\Type\Constant\ConstantBooleanType && $type_1->getValue() === false)
-                ) 
-                &&
-                (
-                    $type_2 instanceof \PHPStan\Type\IntegerType 
-                    ||
-                    (
-                        $type_2 instanceof \PHPStan\Type\UnionType 
-                        &&
-                        $type_2->getTypes()[0] instanceof \PHPStan\Type\IntegerType
-                        &&
-                        $type_2->getTypes()[1] instanceof \PHPStan\Type\NullType
-                    )
-                )
-            ) {
-                $errors[] = \PHPStan\Rules\RuleErrorBuilder::message('Please do not use double negative integer conditions. e.g. `(int)$foo != 0` is the same as `(int)$foo`.')->line($cond->getAttribute('startLine'))->build();
-            }
-
-            if (
-                (
-                    ($type_1 instanceof \PHPStan\Type\Constant\ConstantStringType && $type_1->getValue() === '') 
-                    ||
-                    ($type_1 instanceof \PHPStan\Type\Constant\ConstantIntegerType && $type_1->getValue() === 0) 
-                    ||
-                    ($type_1 instanceof \PHPStan\Type\Constant\ConstantBooleanType && $type_1->getValue() === false)
-                ) 
-                &&
-                (
-                    $type_2 instanceof \PHPStan\Type\BooleanType 
-                    ||
-                    (
-                        $type_2 instanceof \PHPStan\Type\UnionType 
-                        &&
-                        $type_2->getTypes()[0] instanceof \PHPStan\Type\BooleanType 
-                        && 
-                        $type_2->getTypes()[1] instanceof \PHPStan\Type\NullType
-                    )
-                )
-            ) {
-                $errors[] = \PHPStan\Rules\RuleErrorBuilder::message('Please do not use double negative boolean conditions. e.g. `(bool)$foo != false` is the same as `(bool)$foo`.')->line($cond->getAttribute('startLine'))->build();
-            }
-
-            // NULL checks are difficult and maybe unexpected, so that we should use strict check here
-            // https://3v4l.org/a4VdC
-            if (
-                $type_1 instanceof \PHPStan\Type\ConstantScalarType 
-                &&
-                $type_1->getValue() === null 
-                &&
-                (
-                    (
-                        $type_2 instanceof \PHPStan\Type\UnionType 
-                        &&
-                        $type_2->getTypes()[0] instanceof \PHPStan\Type\IntegerType 
-                        &&
-                        $type_2->getTypes()[1] instanceof \PHPStan\Type\NullType
-                    )
-                    ||
-                    (
-                        $type_2 instanceof \PHPStan\Type\UnionType 
-                        &&
-                        $type_2->getTypes()[0] instanceof \PHPStan\Type\StringType 
-                        &&
-                        $type_2->getTypes()[1] instanceof \PHPStan\Type\NullType
-                    )
-                )
-            ) {
-                $errors[] = \PHPStan\Rules\RuleErrorBuilder::message('Please do not use double negative null conditions. Use "!==" instead if needed.')->line($cond->getAttribute('startLine'))->build();
-            }
-
-        }
+        self::processNotEqualRules($type_1, $type_2, $cond, $errors);
 
         // -----------------------------------------------------------------------------------------
 
-        foreach ($classesNotInIfConditions as $classesNotInIfCondition) {
-            if (
-                $type_1 instanceof \PHPStan\Type\ObjectType 
-                &&
-                \is_a($type_1->getClassName(), $classesNotInIfCondition, true)
-            ) {
-                $errors[] = \PHPStan\Rules\RuleErrorBuilder::message('Use a method to check the condition e.g. `$foo->value()` instead of `$foo`.')->line($cond->getAttribute('startLine'))->build();
-            }
-        }
+        self::processBooleanComparison($type_1, $type_2, $cond, $errors);
 
         // -----------------------------------------------------------------------------------------
+
+        self::processObjectMethodUsageForComparison($type_1, $cond, $errors, $classesNotInIfConditions);
+
+        // -----------------------------------------------------------------------------------------
+
+        self::processObjectComparison($type_1, $type_2, $cond, $errors);
+
+        // -----------------------------------------------------------------------------------------
+
+        self::processNonEmptyStrings($type_1, $type_2, $cond, $errors);
+
+        // -----------------------------------------------------------------------------------------
+
+        return $errors;
+    }
+
+    /**
+     * @param \PHPStan\Type\Type|null $type_1
+     * @param \PHPStan\Type\Type|null $type_2
+     * @param Node $cond
+     * @param array<int, \PHPStan\Rules\RuleError> $errors
+     *
+     * @throws \PHPStan\ShouldNotHappenException
+     */
+    private static function processNotEqualRules(
+        ?\PHPStan\Type\Type $type_1,
+        ?\PHPStan\Type\Type $type_2,
+        Node                $cond,
+        array               &$errors
+    ): void
+    {
+        if (! $cond instanceof \PhpParser\Node\Expr\BinaryOp\NotEqual) {
+            return;
+        }
 
         if (
-            $type_1 instanceof \PHPStan\Type\BooleanType 
+            $type_1 instanceof \PHPStan\Type\Constant\ConstantStringType
             &&
-            $type_2 instanceof \PHPStan\Type\Constant\ConstantIntegerType
+            $type_1->getValue() === ''
+            &&
+            $type_2 instanceof \PHPStan\Type\StringType
         ) {
+            $errors[] = \PHPStan\Rules\RuleErrorBuilder::message('Please do not use double negative string conditions. e.g. `(string)$foo != \'\'` is the same as `(string)$foo`.')->line($cond->getAttribute('startLine'))->build();
+        }
+
+        if (
+            (
+                ($type_1 instanceof \PHPStan\Type\Constant\ConstantStringType && $type_1->getValue() === '')
+                ||
+                ($type_1 instanceof \PHPStan\Type\Constant\ConstantIntegerType && $type_1->getValue() === 0)
+                ||
+                ($type_1 instanceof \PHPStan\Type\Constant\ConstantBooleanType && $type_1->getValue() === false)
+            )
+            &&
+            (
+                $type_2 instanceof \PHPStan\Type\IntegerType
+                ||
+                (
+                    $type_2 instanceof \PHPStan\Type\UnionType
+                    &&
+                    $type_2->getTypes()[0] instanceof \PHPStan\Type\IntegerType
+                    &&
+                    $type_2->getTypes()[1] instanceof \PHPStan\Type\NullType
+                )
+            )
+        ) {
+            $errors[] = \PHPStan\Rules\RuleErrorBuilder::message('Please do not use double negative integer conditions. e.g. `(int)$foo != 0` is the same as `(int)$foo`.')->line($cond->getAttribute('startLine'))->build();
+        }
+
+        if (
+            (
+                ($type_1 instanceof \PHPStan\Type\Constant\ConstantStringType && $type_1->getValue() === '')
+                ||
+                ($type_1 instanceof \PHPStan\Type\Constant\ConstantIntegerType && $type_1->getValue() === 0)
+                ||
+                ($type_1 instanceof \PHPStan\Type\Constant\ConstantBooleanType && $type_1->getValue() === false)
+            )
+            &&
+            (
+                $type_2 instanceof \PHPStan\Type\BooleanType
+                ||
+                (
+                    $type_2 instanceof \PHPStan\Type\UnionType
+                    &&
+                    $type_2->getTypes()[0] instanceof \PHPStan\Type\BooleanType
+                    &&
+                    $type_2->getTypes()[1] instanceof \PHPStan\Type\NullType
+                )
+            )
+        ) {
+            $errors[] = \PHPStan\Rules\RuleErrorBuilder::message('Please do not use double negative boolean conditions. e.g. `(bool)$foo != false` is the same as `(bool)$foo`.')->line($cond->getAttribute('startLine'))->build();
+        }
+
+        // NULL checks are difficult and maybe unexpected, so that we should use strict check here
+        // https://3v4l.org/a4VdC
+        if (
+            $type_1 instanceof \PHPStan\Type\ConstantScalarType
+            &&
+            $type_1->getValue() === null
+            &&
+            (
+                (
+                    $type_2 instanceof \PHPStan\Type\UnionType
+                    &&
+                    $type_2->getTypes()[0] instanceof \PHPStan\Type\IntegerType
+                    &&
+                    $type_2->getTypes()[1] instanceof \PHPStan\Type\NullType
+                )
+                ||
+                (
+                    $type_2 instanceof \PHPStan\Type\UnionType
+                    &&
+                    $type_2->getTypes()[0] instanceof \PHPStan\Type\StringType
+                    &&
+                    $type_2->getTypes()[1] instanceof \PHPStan\Type\NullType
+                )
+            )
+        ) {
+            $errors[] = \PHPStan\Rules\RuleErrorBuilder::message('Please do not use double negative null conditions. Use "!==" instead if needed.')->line($cond->getAttribute('startLine'))->build();
+        }
+    }
+
+    /**
+     * @param \PHPStan\Type\Type|null $type_1
+     * @param \PHPStan\Type\Type|null $type_2
+     * @param Node $cond
+     * @param array<int, \PHPStan\Rules\RuleError> $errors
+     *
+     * @throws \PHPStan\ShouldNotHappenException
+     */
+    private static function processBooleanComparison(
+        ?\PHPStan\Type\Type $type_1,
+        ?\PHPStan\Type\Type $type_2,
+        Node                $cond,
+        array               &$errors
+    ): void
+    {
+        if (! $type_1 instanceof \PHPStan\Type\BooleanType) {
+            return;
+        }
+
+        if ($type_2 instanceof \PHPStan\Type\Constant\ConstantIntegerType) {
             $errors[] = \PHPStan\Rules\RuleErrorBuilder::message('Do not compare boolean and integer.')->line($cond->getAttribute('startLine'))->build();
         }
 
-        if (
-            $type_1 instanceof \PHPStan\Type\BooleanType 
-            &&
-            $type_2 instanceof \PHPStan\Type\Constant\ConstantStringType
-            
-        ) {
+        if ($type_2 instanceof \PHPStan\Type\Constant\ConstantStringType) {
             $errors[] = \PHPStan\Rules\RuleErrorBuilder::message('Do not compare boolean and string.')->line($cond->getAttribute('startLine'))->build();
         }
+    }
 
-        // -----------------------------------------------------------------------------------------
-
+    /**
+     * @param \PHPStan\Type\Type|null $type_1
+     * @param \PHPStan\Type\Type|null $type_2
+     * @param Node $cond
+     * @param array<int, \PHPStan\Rules\RuleError> $errors
+     *
+     * @throws \PHPStan\ShouldNotHappenException
+     */
+    private static function processObjectComparison(
+        ?\PHPStan\Type\Type $type_1,
+        ?\PHPStan\Type\Type $type_2,
+        Node                $cond,
+        array               &$errors
+    ): void
+    {
         if (
-            $type_1 instanceof \PHPStan\Type\ObjectType 
-            &&
-            $type_2 instanceof \PHPStan\Type\Type
-            &&
-            !(
-                $type_2 instanceof \PHPStan\Type\ObjectType
-                ||
-                $type_2 instanceof \PHPStan\Type\ThisType
-                ||
-                $type_2 instanceof \PHPStan\Type\NullType
-                ||
-                (    
-                    $type_2 instanceof \PHPStan\Type\UnionType
-                    &&
-                    $type_2->getTypes()[1] instanceof \PHPStan\Type\NullType
-                    &&
-                    (
-                        $type_2->getTypes()[0] instanceof \PHPStan\Type\ObjectType
-                        ||
-                        $type_2->getTypes()[0] instanceof \PHPStan\Type\ThisType
-                    )
-                )
-            )
-            && 
-            !(
-                (
-                    $cond instanceof \PhpParser\Node\Expr\BinaryOp\Identical
-                    ||
-                    $cond instanceof \PhpParser\Node\Expr\BinaryOp\NotIdentical
-                )
-                &&
-                $type_1 instanceof \PHPStan\Type\Enum\EnumCaseObjectType
-                &&
-                $type_2 instanceof \PHPStan\Type\UnionType
-                &&
-                $type_2->isSuperTypeOf($type_1)->yes()
-            )
+            ! $type_1 instanceof \PHPStan\Type\ObjectType
+            ||
+            ! $type_2 instanceof \PHPStan\Type\Type
         ) {
-            $errors[] = \PHPStan\Rules\RuleErrorBuilder::message('Do not compare objects directly.')->line($cond->getAttribute('startLine'))->build();
+            return;
         }
 
-        // -----------------------------------------------------------------------------------------
+        if (
+            $type_2 instanceof \PHPStan\Type\ObjectType
+            ||
+            $type_2 instanceof \PHPStan\Type\ThisType
+            ||
+            $type_2 instanceof \PHPStan\Type\NullType
+            ||
+            (
+                $type_2 instanceof \PHPStan\Type\UnionType
+                &&
+                $type_2->getTypes()[1] instanceof \PHPStan\Type\NullType
+                &&
+                (
+                    $type_2->getTypes()[0] instanceof \PHPStan\Type\ObjectType
+                    ||
+                    $type_2->getTypes()[0] instanceof \PHPStan\Type\ThisType
+                )
+            )
+        ) {
+            return;
+        }
 
         if (
-            $cond instanceof \PhpParser\Node\Expr\BinaryOp\NotEqual 
-            ||
-            $cond instanceof \PhpParser\Node\Expr\BinaryOp\NotIdentical 
+            (
+                $cond instanceof \PhpParser\Node\Expr\BinaryOp\Identical
+                ||
+                $cond instanceof \PhpParser\Node\Expr\BinaryOp\NotIdentical
+            )
+            &&
+            $type_1 instanceof \PHPStan\Type\Enum\EnumCaseObjectType
+            &&
+            $type_2 instanceof \PHPStan\Type\UnionType
+            &&
+            $type_2->isSuperTypeOf($type_1)->yes()
         ) {
-            if (
-                $type_1 instanceof \PHPStan\Type\Constant\ConstantStringType 
-                &&
-                $type_1->getValue() === ''
-                &&
-                $type_2->isNonEmptyString()->yes()
-                
-            ) {
-                $errors[] = \PHPStan\Rules\RuleErrorBuilder::message('Non-empty string is never empty.')->line($cond->getAttribute('startLine'))->build();
-            }
+            return;
+        }
+
+        $errors[] = \PHPStan\Rules\RuleErrorBuilder::message('Do not compare objects directly.')->line($cond->getAttribute('startLine'))->build();
+    }
+
+    /**
+     * @param \PHPStan\Type\Type|null $type_1
+     * @param \PHPStan\Type\Type|null $type_2
+     * @param Node $cond
+     * @param array<int, \PHPStan\Rules\RuleError> $errors
+     *
+     * @throws \PHPStan\ShouldNotHappenException
+     */
+    private static function processNonEmptyStrings(
+        ?\PHPStan\Type\Type $type_1,
+        ?\PHPStan\Type\Type $type_2,
+        Node                $cond,
+        array               &$errors
+    ): void
+    {
+        if (!(
+            $type_1 instanceof \PHPStan\Type\Constant\ConstantStringType
+            &&
+            $type_1->getValue() === ''
+            &&
+            $type_2->isNonEmptyString()->yes()
+
+        )) {
+            return;
+        }
+
+        if (
+            $cond instanceof \PhpParser\Node\Expr\BinaryOp\NotEqual
+            ||
+            $cond instanceof \PhpParser\Node\Expr\BinaryOp\NotIdentical
+        ) {
+            $errors[] = \PHPStan\Rules\RuleErrorBuilder::message('Non-empty string is never empty.')->line($cond->getAttribute('startLine'))->build();
         }
 
         if (
@@ -217,20 +291,33 @@ final class IfConditionHelper
             ||
             $cond instanceof \PhpParser\Node\Expr\BinaryOp\Identical
         ) {
-            if (
-                $type_1 instanceof \PHPStan\Type\Constant\ConstantStringType
-                &&
-                $type_1->getValue() === ''
-                &&
-                $type_2->isNonEmptyString()->yes()
+            $errors[] = \PHPStan\Rules\RuleErrorBuilder::message('Non-empty string is always non-empty.')->line($cond->getAttribute('startLine'))->build();
+        }
+    }
 
+    /**
+     * @param \PHPStan\Type\Type|null $type_1
+     * @param Node $cond
+     * @param array<int, \PHPStan\Rules\RuleError> $errors
+     * @param array<int, class-string> $classesNotInIfConditions
+     *
+     * @throws \PHPStan\ShouldNotHappenException
+     */
+    private static function processObjectMethodUsageForComparison(
+        ?\PHPStan\Type\Type $type_1,
+        Node                $cond,
+        array               &$errors,
+        array               $classesNotInIfConditions
+    ): void
+    {
+        foreach ($classesNotInIfConditions as $classesNotInIfCondition) {
+            if (
+                $type_1 instanceof \PHPStan\Type\ObjectType
+                &&
+                \is_a($type_1->getClassName(), $classesNotInIfCondition, true)
             ) {
-                $errors[] = \PHPStan\Rules\RuleErrorBuilder::message('Non-empty string is always non-empty.')->line($cond->getAttribute('startLine'))->build();
+                $errors[] = \PHPStan\Rules\RuleErrorBuilder::message('Use a method to check the condition e.g. `$foo->value()` instead of `$foo`.')->line($cond->getAttribute('startLine'))->build();
             }
         }
-
-        // -----------------------------------------------------------------------------------------
-
-        return $errors;
     }
 }

--- a/tests/IfConditionBooleanAndRuleTest.php
+++ b/tests/IfConditionBooleanAndRuleTest.php
@@ -30,7 +30,7 @@ final class IfConditionBooleanAndRuleTest extends RuleTestCase
                     8,
                 ],
                 [
-                    'Do not compare objects directly.',
+                    'Do not compare objects directly, stdClass found.',
                     8,
                 ],
             ]

--- a/tests/IfConditionRuleTest.php
+++ b/tests/IfConditionRuleTest.php
@@ -42,7 +42,7 @@ final class IfConditionRuleTest extends RuleTestCase
                     19
                 ],
                 [
-                    'Do not compare objects directly.',
+                    'Do not compare objects directly, stdClass found.',
                     19,
                 ],
                 [
@@ -66,27 +66,27 @@ final class IfConditionRuleTest extends RuleTestCase
                     44
                 ],
                 [
-                    'Do not compare objects directly.',
+                    'Do not compare objects directly, stdClass found.',
                     44
                 ],
                 [
-                    'Do not compare objects directly.',
+                    'Do not compare objects directly, DateTimeImmutable found.',
                     49
                 ],
                 [
-                    'Do not compare objects directly.',
+                    'Do not compare objects directly, DateTimeImmutable found.',
                     52
                 ],
                 [
-                    'Do not compare objects directly.',
+                    'Do not compare objects directly, DateTimeImmutable found.',
                     55
                 ],
                 [
-                    'Do not compare objects directly.',
+                    'Do not compare objects directly, DateTimeImmutable found.',
                     72
                 ],
                 [
-                    'Do not compare objects directly.',
+                    'Do not compare objects directly, DateTimeImmutable|null found.',
                     87
                 ],
             ]
@@ -104,11 +104,11 @@ final class IfConditionRuleTest extends RuleTestCase
             ],
             [
                 [
-                    'Do not compare objects directly.',
+                    'Do not compare objects directly, voku\PHPStan\Rules\Test\fixtures\BulbOn::ON found.',
                     12
                 ],
                 [
-                    'Do not compare objects directly.',
+                    'Do not compare objects directly, voku\PHPStan\Rules\Test\fixtures\BulbOn::OFF|voku\PHPStan\Rules\Test\fixtures\BulbOn::ON found.',
                     12
                 ],
             ]

--- a/tests/IfConditionRuleTest.php
+++ b/tests/IfConditionRuleTest.php
@@ -85,6 +85,10 @@ final class IfConditionRuleTest extends RuleTestCase
                     'Do not compare objects directly.',
                     72
                 ],
+                [
+                    'Do not compare objects directly.',
+                    87
+                ],
             ]
         );
     }
@@ -99,6 +103,10 @@ final class IfConditionRuleTest extends RuleTestCase
                 __DIR__ . '/fixtures/IfConditionsFixtures81.php',
             ],
             [
+                [
+                    'Do not compare objects directly.',
+                    12
+                ],
                 [
                     'Do not compare objects directly.',
                     12

--- a/tests/IfConditionRuleTest.php
+++ b/tests/IfConditionRuleTest.php
@@ -89,6 +89,14 @@ final class IfConditionRuleTest extends RuleTestCase
                     'Do not compare objects directly, DateTimeImmutable|null found.',
                     87
                 ],
+                [
+                    'Do not compare objects directly, DateTimeImmutable|null found.',
+                    97
+                ],
+                [
+                    'Do not compare objects directly, DateTimeImmutable found.',
+                    97
+                ],
             ]
         );
     }

--- a/tests/IfConditionTernaryOperatorRuleTest.php
+++ b/tests/IfConditionTernaryOperatorRuleTest.php
@@ -31,7 +31,7 @@ final class IfConditionTernaryOperatorRuleTest extends RuleTestCase
                     7,
                 ],
                 [
-                    'Do not compare objects directly.',
+                    'Do not compare objects directly, stdClass found.',
                     7,
                 ],
             ]

--- a/tests/IfConditionTernaryOperatorRuleTest.php
+++ b/tests/IfConditionTernaryOperatorRuleTest.php
@@ -30,6 +30,10 @@ final class IfConditionTernaryOperatorRuleTest extends RuleTestCase
                     'Use a method to check the condition e.g. `$foo->value()` instead of `$foo`.',
                     7,
                 ],
+                [
+                    'Do not compare objects directly.',
+                    7,
+                ],
             ]
         );
     }

--- a/tests/fixtures/IfConditionsFixtures.php
+++ b/tests/fixtures/IfConditionsFixtures.php
@@ -81,3 +81,14 @@ if (isset($a[$rand])) {
     $b = null;
 }
 $b = $a[$rand] ?? null;
+
+if ($date instanceof \DateTimeImmutable || $date === null) {
+    // Do not compare nullable objects on non-strict binary operators
+    if ($date < '2013-04-05') {
+        //
+    }
+
+    if ($date === null) {
+        //
+    }
+}

--- a/tests/fixtures/IfConditionsFixtures.php
+++ b/tests/fixtures/IfConditionsFixtures.php
@@ -88,7 +88,20 @@ if ($date instanceof \DateTimeImmutable || $date === null) {
         //
     }
 
+    // Allow strict comparison
     if ($date === null) {
         //
+    }
+
+    // Do not compare nullable DateTime
+    if ($date < new \DateTimeImmutable()) {
+        //
+    }
+
+    if ($date !== null) {
+        // Allow DateTime comparison when type is certain
+        if ($date < new \DateTimeImmutable()) {
+            //
+        }
     }
 }


### PR DESCRIPTION
Hi, here the instructions to review this PR efficiently:

1. First commit https://github.com/voku/phpstan-rules/commit/fd9e7cc1cf96306cfcf499db149b923d19adc60b only splits logic into separate methods so we can leverage [Replace Nested Conditional with Guard Clauses](https://refactoring.com/catalog/replaceNestedConditionalWithGuardClauses.html), as `if` were going a bit too crazy
2. Second commit does the topic: `===` and `!==` are *always* safe as far as I can tell, no way they can return `true` if not intended by programmer; in the same category falls `??` operator
3. Third commit https://github.com/voku/phpstan-rules/commit/84543c8f713b0503923be14b4afcb0ebe4bb201b describe the variable/object that triggers the error, as I sometimes wandered if the culprit is the left or right part, and I also need to know what PHPStan knows about the variable
4. Fourth commit https://github.com/voku/phpstan-rules/commit/e7fe71927510cf6df4b0f6e32e554019f68bb3d2 allow loose comparison between `DateTime`/`DateTimeImmutable` objects as PHP knows how to do it properly (see [`php_date.c#L1663`](https://github.com/php/php-src/blob/de54f83b2360f1984ac4e13d01d47f3f08401c58/ext/date/php_date.c#L1663) and [`php_date.c#L1671`](https://github.com/php/php-src/blob/de54f83b2360f1984ac4e13d01d47f3f08401c58/ext/date/php_date.c#L1671)) but only when type is certain: no `nullable` allowed as per https://3v4l.org/dOiTf#v8.1.5

Following this refactor, now **both** left and right parts of a binary op raise and error if both should be make explicit, this is intended and adhere to PHPStan similar rules.

