### PR TITLE
Fix Yoda configuration propagation and array operator checks

### DIFF
--- a/rules.neon
+++ b/rules.neon
@@ -68,7 +68,7 @@ services:
 			checkYodaConditions: %voku.checkYodaConditions%
 			checkForAssignments: %voku.checkForAssignments%
 		tags:
-			- phpstan.rules.rule
+			- phpstan.rules.rule		
 			
 	-
 		class: voku\PHPStan\Rules\IfConditionBasicRule
@@ -93,6 +93,7 @@ services:
 		arguments:
 			classesNotInIfConditions: %voku.classesNotInIfConditions%
 			checkForAssignments: %voku.checkForAssignments%
+			checkYodaConditions: %voku.checkYodaConditions%
 		tags:
 			- phpstan.rules.rule
 
@@ -101,6 +102,7 @@ services:
 		arguments:
 			classesNotInIfConditions: %voku.classesNotInIfConditions%
 			checkForAssignments: %voku.checkForAssignments%
+			checkYodaConditions: %voku.checkYodaConditions%
 		tags:
 			- phpstan.rules.rule
 			
@@ -109,5 +111,6 @@ services:
 		arguments:
 			classesNotInIfConditions: %voku.classesNotInIfConditions%
 			checkForAssignments: %voku.checkForAssignments%
+			checkYodaConditions: %voku.checkYodaConditions%
 		tags:
 			- phpstan.rules.rule

--- a/src/voku/PHPStan/Rules/ExtendedAssignOpRule.php
+++ b/src/voku/PHPStan/Rules/ExtendedAssignOpRule.php
@@ -27,7 +27,7 @@ class ExtendedAssignOpRule implements Rule
      * @var bool
      */
     private $checkYodaConditions;
-    
+
     /**
      * @var ReflectionProvider
      */
@@ -40,9 +40,9 @@ class ExtendedAssignOpRule implements Rule
     )
     {
         $this->reflectionProvider = $reflectionProvider;
-        
+
         $this->checkForAssignments = $checkForAssignments;
-        
+
         $this->checkYodaConditions = $checkYodaConditions;
     }
 
@@ -58,14 +58,10 @@ class ExtendedAssignOpRule implements Rule
      */
     public function processNode(Node $node, Scope $scope): array
     {
-        // init
         $errors = [];
 
         $leftType = $scope->getType($node->var);
         $rightType = $scope->getType($node->expr);
-
-        // DEBUG
-        //var_dump($leftType, $rightType);
 
         $errors = IfConditionHelper::processNodeHelper(
             $leftType,
@@ -120,9 +116,6 @@ class ExtendedAssignOpRule implements Rule
             &&
             $type_2->describe(VerbosityLevel::typeOnly()) !== 'string' // INFO: hack for non-empty-string
         ) {
-            // INFO:
-            // string concatenation is allowed only with string compatible types
-            // == and != are allowed only with string compatible types
             if (
                 $node instanceof Node\Expr\AssignOp\Concat
                 &&
@@ -144,7 +137,7 @@ class ExtendedAssignOpRule implements Rule
             );
 
             $errorsFound = true;
-            
+
             return;
         }
 
@@ -153,13 +146,7 @@ class ExtendedAssignOpRule implements Rule
             &&
             !($type_2 instanceof \PHPStan\Type\MixedType)
             &&
-            !IfConditionHelper::isPhpStanTypeMaybeWithUnionNullable($type_2, \PHPStan\Type\ArrayType::class)
-            &&
-            !IfConditionHelper::isPhpStanTypeMaybeWithUnionNullable($type_2, \PHPStan\Type\Constant\ConstantArrayType::class, false)
-            &&
-            !IfConditionHelper::isPhpStanTypeMaybeWithUnionNullable($type_2, \PHPStan\Type\Accessory\NonEmptyArrayType::class, false)
-            &&
-            \strpos($type_2->describe(VerbosityLevel::typeOnly()), 'non-empty-array') !== false
+            $type_2->isArray()->no()
         ) {
             $errors[] = IfConditionHelper::buildErrorMessage(
                 $node,

--- a/src/voku/PHPStan/Rules/ExtendedBinaryOpRule.php
+++ b/src/voku/PHPStan/Rules/ExtendedBinaryOpRule.php
@@ -29,14 +29,10 @@ class ExtendedBinaryOpRule implements Rule
      */
     public function processNode(Node $node, Scope $scope): array
     {
-        // init
         $errors = [];
 
         $leftType = $scope->getType($node->left);
         $rightType = $scope->getType($node->right);
-
-        // DEBUG
-        //var_dump($leftType, $rightType);
 
         $errorsFound = false;
         $this->checkErrors($node, $leftType, $rightType, $errors, $errorsFound);
@@ -59,7 +55,6 @@ class ExtendedBinaryOpRule implements Rule
         bool               &$errorsFound
     ): void
     {
-        // if contains are checked separately
         if (
             $node instanceof \PhpParser\Node\Expr\BinaryOp\Identical
             ||
@@ -83,9 +78,6 @@ class ExtendedBinaryOpRule implements Rule
             &&
             $type_2->describe(VerbosityLevel::typeOnly()) !== 'string' // INFO: hack for non-empty-string
         ) {
-            // INFO:
-            // string concatenation is allowed only with string compatible types
-            // == and != are allowed only with string compatible types
             if (
                 (
                     $node instanceof Node\Expr\BinaryOp\Concat
@@ -113,7 +105,7 @@ class ExtendedBinaryOpRule implements Rule
             );
 
             $errorsFound = true;
-            
+
             return;
         }
 
@@ -122,13 +114,7 @@ class ExtendedBinaryOpRule implements Rule
             &&
             !($type_2 instanceof \PHPStan\Type\MixedType)
             &&
-            !IfConditionHelper::isPhpStanTypeMaybeWithUnionNullable($type_2, \PHPStan\Type\ArrayType::class)
-            &&
-            !IfConditionHelper::isPhpStanTypeMaybeWithUnionNullable($type_2, \PHPStan\Type\Constant\ConstantArrayType::class, false)
-            &&
-            !IfConditionHelper::isPhpStanTypeMaybeWithUnionNullable($type_2, \PHPStan\Type\Accessory\NonEmptyArrayType::class, false)
-            &&
-            \strpos($type_2->describe(VerbosityLevel::typeOnly()), 'non-empty-array') !== false // INFO: hack for non-empty-array
+            $type_2->isArray()->no()
         ) {
             $errors[] = IfConditionHelper::buildErrorMessage(
                 $node,

--- a/src/voku/PHPStan/Rules/IfConditionMatchRule.php
+++ b/src/voku/PHPStan/Rules/IfConditionMatchRule.php
@@ -14,7 +14,6 @@ use PHPStan\Rules\Rule;
  */
 final class IfConditionMatchRule implements Rule
 {
-
     /**
      * @var array<int, class-string>
      */
@@ -26,24 +25,34 @@ final class IfConditionMatchRule implements Rule
     private $checkForAssignments;
 
     /**
+     * @var bool
+     */
+    private $checkYodaConditions;
+
+    /**
      * @var null|ReflectionProvider
      */
     private $reflectionProvider;
 
     /**
+     * The first three parameters intentionally keep the legacy positional order.
+     *
      * @param array<int, class-string> $classesNotInIfConditions
      */
     public function __construct(
         array $classesNotInIfConditions,
         bool $checkForAssignments = false,
-        ?ReflectionProvider $reflectionProvider = null
+        ?ReflectionProvider $reflectionProvider = null,
+        bool $checkYodaConditions = false
     )
     {
         $this->reflectionProvider = $reflectionProvider;
-        
+
         $this->checkForAssignments = $checkForAssignments;
-        
+
         $this->classesNotInIfConditions = $classesNotInIfConditions;
+
+        $this->checkYodaConditions = $checkYodaConditions;
     }
 
     public function getNodeType(): string
@@ -58,14 +67,13 @@ final class IfConditionMatchRule implements Rule
      */
     public function processNode(Node $node, Scope $scope): array
     {
-        // init
         $errors = [];
 
         foreach ($node->arms as $arm) {
             if ($arm->conds === null) {
                 continue;
             }
-            
+
             foreach ($arm->conds as $case) {
                 $errors = IfConditionHelper::processNodeHelper(
                     $scope->getType($node->cond),
@@ -76,7 +84,7 @@ final class IfConditionMatchRule implements Rule
                     $node,
                     $this->reflectionProvider,
                     $this->checkForAssignments,
-                    false
+                    $this->checkYodaConditions
                 );
 
                 $errors = array_merge(
@@ -91,7 +99,7 @@ final class IfConditionMatchRule implements Rule
                 );
             }
         }
-        
+
         return $errors;
     }
 }

--- a/src/voku/PHPStan/Rules/IfConditionSwitchCaseRule.php
+++ b/src/voku/PHPStan/Rules/IfConditionSwitchCaseRule.php
@@ -14,7 +14,6 @@ use PHPStan\Rules\Rule;
  */
 final class IfConditionSwitchCaseRule implements Rule
 {
-
     /**
      * @var array<int, class-string>
      */
@@ -26,24 +25,34 @@ final class IfConditionSwitchCaseRule implements Rule
     private $checkForAssignments;
 
     /**
+     * @var bool
+     */
+    private $checkYodaConditions;
+
+    /**
      * @var null|ReflectionProvider
      */
     private $reflectionProvider;
 
     /**
+     * The first three parameters intentionally keep the legacy positional order.
+     *
      * @param array<int, class-string> $classesNotInIfConditions
      */
     public function __construct(
         array $classesNotInIfConditions,
         bool $checkForAssignments = false,
-        ?ReflectionProvider $reflectionProvider = null
+        ?ReflectionProvider $reflectionProvider = null,
+        bool $checkYodaConditions = false
     )
     {
         $this->reflectionProvider = $reflectionProvider;
-        
+
         $this->checkForAssignments = $checkForAssignments;
-        
+
         $this->classesNotInIfConditions = $classesNotInIfConditions;
+
+        $this->checkYodaConditions = $checkYodaConditions;
     }
 
     public function getNodeType(): string
@@ -58,7 +67,6 @@ final class IfConditionSwitchCaseRule implements Rule
      */
     public function processNode(Node $node, Scope $scope): array
     {
-        // init
         $errors = [];
 
         foreach ($node->cases as $case) {
@@ -71,7 +79,7 @@ final class IfConditionSwitchCaseRule implements Rule
                 $node,
                 $this->reflectionProvider,
                 $this->checkForAssignments,
-                false
+                $this->checkYodaConditions
             );
 
             if ($case->cond !== null) {
@@ -87,7 +95,7 @@ final class IfConditionSwitchCaseRule implements Rule
                 );
             }
         }
-        
+
         return $errors;
     }
 }

--- a/src/voku/PHPStan/Rules/IfConditionTernaryOperatorRule.php
+++ b/src/voku/PHPStan/Rules/IfConditionTernaryOperatorRule.php
@@ -14,7 +14,6 @@ use PHPStan\Rules\Rule;
  */
 final class IfConditionTernaryOperatorRule implements Rule
 {
-
     /**
      * @var array<int, class-string>
      */
@@ -24,6 +23,11 @@ final class IfConditionTernaryOperatorRule implements Rule
      * @var bool
      */
     private $checkForAssignments;
+
+    /**
+     * @var bool
+     */
+    private $checkYodaConditions;
 
     /**
      * @var null|ReflectionProvider
@@ -36,14 +40,17 @@ final class IfConditionTernaryOperatorRule implements Rule
     public function __construct(
         array $classesNotInIfConditions,
         ?ReflectionProvider $reflectionProvider = null,
-        bool                $checkForAssignments = false
+        bool                $checkForAssignments = false,
+        bool                $checkYodaConditions = false
     )
     {
         $this->reflectionProvider = $reflectionProvider;
-        
+
         $this->classesNotInIfConditions = $classesNotInIfConditions;
 
         $this->checkForAssignments = $checkForAssignments;
+
+        $this->checkYodaConditions = $checkYodaConditions;
     }
 
     public function getNodeType(): string
@@ -83,7 +90,8 @@ final class IfConditionTernaryOperatorRule implements Rule
             $this->classesNotInIfConditions,
             $node,
             $this->reflectionProvider,
-            $this->checkForAssignments
+            $this->checkForAssignments,
+            $this->checkYodaConditions
         );
     }
 
@@ -100,7 +108,8 @@ final class IfConditionTernaryOperatorRule implements Rule
             $this->classesNotInIfConditions,
             $origNode,
             $this->reflectionProvider,
-            $this->checkForAssignments
+            $this->checkForAssignments,
+            $this->checkYodaConditions
         );
     }
 }

--- a/tests/ExtendedAssignOpRuleTest.php
+++ b/tests/ExtendedAssignOpRuleTest.php
@@ -42,7 +42,7 @@ final class ExtendedAssignOpRuleTest extends RuleTestCase
                     16,
                 ],
                 [
-                    'Plus: string (\'foo\') in combination with non-string (array{lall: int, foo: 1}) is not allowed.',
+                    'Plus: array (array{lall: int, foo: 1}) in combination with non-array (\'foo\') is not allowed.',
                     28,
                 ],
                 [

--- a/tests/ExtendedOpRuleArrayCheckTest.php
+++ b/tests/ExtendedOpRuleArrayCheckTest.php
@@ -4,32 +4,14 @@ declare(strict_types=1);
 
 namespace voku\PHPStan\Rules\Test;
 
-use PhpParser\Node;
-use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
-use PHPStan\Type\VerbosityLevel;
 use voku\PHPStan\Rules\ExtendedAssignOpRule;
 use voku\PHPStan\Rules\ExtendedBinaryOpRule;
 
 /**
- * ExtendedBinaryOpRule and ExtendedAssignOpRule both contain a branch that is supposed to report
- * "array (...) in combination with non-array (...) is not allowed." - the array counterpart of the
- * string check next to it. No test in this repository ever asserted that message, and it turns out
- * the branch cannot fire.
- *
- * Its last condition is:
- *
- *     \strpos($type_2->describe(VerbosityLevel::typeOnly()), 'non-empty-array') !== false
- *
- * `VerbosityLevel::typeOnly()` strips accessory types, so a `non-empty-array<int, string>` is
- * described as `array<int, string>` and the needle is never present. The comparison looks like the
- * `!== 'string'` hack directly above it, where `typeOnly()` *does* produce the needle, so the
- * inversion is easy to miss by reading.
- *
- * These tests pin both halves of that: the observable behaviour today (no error is reported) and
- * the type-description fact the branch depends on. Fixing the branch - tracked as VPR-2 on the
- * board - has to make the first test fail, which is the point of writing it down.
+ * VPR-2 regression coverage for the array/non-array branch shared by both extended operator rules.
+ * Definite non-arrays are reported; arrays, including non-empty-array accessory types, stay valid.
  *
  * @extends RuleTestCase<Rule>
  */
@@ -51,138 +33,37 @@ final class ExtendedOpRuleArrayCheckTest extends RuleTestCase
         return $this->ruleUnderTest;
     }
 
-    /**
-     * Known defect, see VPR-2: mixing an array with an int or with another array reports nothing.
-     * The only message the fixture produces comes from the *string* branch, for `array == string`,
-     * and it describes the string operand rather than the array one.
-     */
-    public function testExtendedBinaryOpRuleDoesNotReportTheArrayCombinationYet(): void
+    public function testExtendedBinaryOpRuleReportsDefiniteNonArrayOperands(): void
     {
         $this->ruleUnderTest = new ExtendedBinaryOpRule();
 
-        $messages = $this->gatherMessages([self::FIXTURE]);
-
-        static::assertSame(
+        $this->analyse(
+            [self::FIXTURE],
             [
-                '29: Equal: string (string) in combination with non-string (array<int, string>) is not allowed.',
-            ],
-            $messages
+                [
+                    'Equal: array (array<int, string>) in combination with non-array (int) is not allowed.',
+                    18,
+                ],
+                [
+                    'Equal: array (array<int, string>) in combination with non-array (string) is not allowed.',
+                    26,
+                ],
+            ]
         );
-        self::assertNoArrayCombinationMessage($messages);
     }
 
-    /**
-     * Known defect, see VPR-2.
-     */
-    public function testExtendedAssignOpRuleDoesNotReportTheArrayCombinationYet(): void
+    public function testExtendedAssignOpRuleReportsDefiniteNonArrayOperands(): void
     {
         $this->ruleUnderTest = new ExtendedAssignOpRule($this->createReflectionProvider());
 
-        $messages = $this->gatherMessages([self::FIXTURE]);
-
-        static::assertSame([], $messages);
-        self::assertNoArrayCombinationMessage($messages);
-    }
-
-    /**
-     * @param array<int, string> $files
-     *
-     * @return array<int, string>
-     */
-    private function gatherMessages(array $files): array
-    {
-        $messages = [];
-        foreach ($this->gatherAnalyserErrors($files) as $error) {
-            $messages[] = $error->getLine() . ': ' . $error->getMessage();
-        }
-
-        \sort($messages);
-
-        return $messages;
-    }
-
-    /**
-     * @param array<int, string> $messages
-     */
-    private static function assertNoArrayCombinationMessage(array $messages): void
-    {
-        foreach ($messages as $message) {
-            static::assertStringNotContainsString('in combination with non-array', $message);
-        }
-    }
-
-    /**
-     * The reason the branch is unreachable, asserted directly against PHPStan instead of against
-     * prose: `typeOnly()` never yields the "non-empty-array" needle the branch looks for, while
-     * `value()` does. If a future PHPStan release changes that, this test turns red and the dead
-     * branch suddenly becomes live - which is something the maintainer wants to hear about.
-     */
-    public function testTypeOnlyVerbosityNeverContainsTheNonEmptyArrayNeedle(): void
-    {
-        $descriptions = [];
-
-        $this->ruleUnderTest = new class($descriptions) implements Rule {
-            /**
-             * @var array<int, array{typeOnly: string, value: string}>
-             */
-            private $descriptions;
-
-            /**
-             * @param array<int, array{typeOnly: string, value: string}> $descriptions
-             */
-            public function __construct(array &$descriptions)
-            {
-                $this->descriptions = &$descriptions;
-            }
-
-            public function getNodeType(): string
-            {
-                return Node\Expr\BinaryOp::class;
-            }
-
-            /**
-             * @param Node\Expr\BinaryOp $node
-             *
-             * @return array<int, \PHPStan\Rules\RuleError>
-             */
-            public function processNode(Node $node, Scope $scope): array
-            {
-                foreach ([$node->left, $node->right] as $side) {
-                    $type = $scope->getType($side);
-                    if (!$type->isArray()->yes()) {
-                        continue;
-                    }
-
-                    $this->descriptions[] = [
-                        'typeOnly' => $type->describe(VerbosityLevel::typeOnly()),
-                        'value' => $type->describe(VerbosityLevel::value()),
-                    ];
-                }
-
-                return [];
-            }
-        };
-
-        $this->gatherAnalyserErrors([self::FIXTURE]);
-
-        static::assertNotSame([], $descriptions, 'The fixture no longer contains an array operand.');
-
-        $sawNonEmptyArrayAtValueVerbosity = false;
-        foreach ($descriptions as $description) {
-            static::assertStringNotContainsString(
-                'non-empty-array',
-                $description['typeOnly'],
-                'typeOnly() started to expose accessory array types; the dead branch in the Extended*OpRule classes may have become reachable.'
-            );
-
-            if (\strpos($description['value'], 'non-empty-array') !== false) {
-                $sawNonEmptyArrayAtValueVerbosity = true;
-            }
-        }
-
-        static::assertTrue(
-            $sawNonEmptyArrayAtValueVerbosity,
-            'The fixture no longer contains a non-empty-array operand, so this test proves nothing.'
+        $this->analyse(
+            [self::FIXTURE],
+            [
+                [
+                    'Plus: array (array<int, string>) in combination with non-array (int) is not allowed.',
+                    45,
+                ],
+            ]
         );
     }
 }

--- a/tests/Vpr8YodaConfigurationTest.php
+++ b/tests/Vpr8YodaConfigurationTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace voku\PHPStan\Rules\Test;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use voku\PHPStan\Rules\IfConditionMatchRule;
+use voku\PHPStan\Rules\IfConditionSwitchCaseRule;
+use voku\PHPStan\Rules\IfConditionTernaryOperatorRule;
+
+/**
+ * Regression coverage for VPR-8: checkYodaConditions has to reach ternary, match and switch rules
+ * without reordering the legacy positional constructor arguments of Match/Switch.
+ *
+ * @extends RuleTestCase<Rule>
+ */
+final class Vpr8YodaConfigurationTest extends RuleTestCase
+{
+    private const TERNARY_FIXTURE = __DIR__ . '/fixtures/Vpr8TernaryFixture.php';
+
+    private const MATCH_FIXTURE = __DIR__ . '/fixtures/Vpr8MatchFixture.php';
+
+    private const SWITCH_FIXTURE = __DIR__ . '/fixtures/Vpr8SwitchFixture.php';
+
+    /**
+     * @var Rule|null
+     */
+    private $ruleUnderTest;
+
+    protected function getRule(): Rule
+    {
+        if ($this->ruleUnderTest === null) {
+            throw new \LogicException('The rule under test has to be selected by the test method.');
+        }
+
+        return $this->ruleUnderTest;
+    }
+
+    public function testTernaryStaysSilentByDefault(): void
+    {
+        $this->ruleUnderTest = new IfConditionTernaryOperatorRule([], $this->createReflectionProvider());
+
+        $this->analyse([self::TERNARY_FIXTURE], []);
+    }
+
+    public function testTernaryHonoursCheckYodaConditions(): void
+    {
+        $this->ruleUnderTest = new IfConditionTernaryOperatorRule([], $this->createReflectionProvider(), false, true);
+
+        $this->analyse([self::TERNARY_FIXTURE], [['Ternary: Yoda condition is not allowed here.', 11]]);
+    }
+
+    /**
+     * @requires PHP 8.0
+     */
+    public function testMatchStaysSilentByDefault(): void
+    {
+        $this->ruleUnderTest = new IfConditionMatchRule([], false, $this->createReflectionProvider());
+
+        $this->analyse([self::MATCH_FIXTURE], []);
+    }
+
+    /**
+     * @requires PHP 8.0
+     */
+    public function testMatchHonoursCheckYodaConditions(): void
+    {
+        $this->ruleUnderTest = new IfConditionMatchRule([], false, $this->createReflectionProvider(), true);
+
+        $this->analyse([self::MATCH_FIXTURE], [['Match_: Yoda condition is not allowed here.', 12]]);
+    }
+
+    public function testSwitchStaysSilentByDefault(): void
+    {
+        $this->ruleUnderTest = new IfConditionSwitchCaseRule([], false, $this->createReflectionProvider());
+
+        $this->analyse([self::SWITCH_FIXTURE], []);
+    }
+
+    public function testSwitchHonoursCheckYodaConditions(): void
+    {
+        $this->ruleUnderTest = new IfConditionSwitchCaseRule([], false, $this->createReflectionProvider(), true);
+
+        $this->analyse([self::SWITCH_FIXTURE], [['Switch_: Yoda condition is not allowed here.', 12]]);
+    }
+
+    public function testLegacyConstructorPositionsAreNotReordered(): void
+    {
+        foreach ([IfConditionMatchRule::class, IfConditionSwitchCaseRule::class] as $ruleClass) {
+            $constructor = (new \ReflectionClass($ruleClass))->getConstructor();
+            static::assertNotNull($constructor);
+
+            $names = \array_map(
+                static function (\ReflectionParameter $parameter): string {
+                    return $parameter->getName();
+                },
+                $constructor->getParameters()
+            );
+
+            static::assertSame(
+                ['classesNotInIfConditions', 'checkForAssignments', 'reflectionProvider', 'checkYodaConditions'],
+                $names
+            );
+        }
+    }
+}

--- a/tests/fixtures/ArrayInCombinationWithNonArrayFixtures.php
+++ b/tests/fixtures/ArrayInCombinationWithNonArrayFixtures.php
@@ -7,9 +7,6 @@ namespace voku\PHPStan\Rules\Test\fixtures;
 /**
  * Operands for the "array (...) in combination with non-array (...) is not allowed." check of
  * ExtendedBinaryOpRule and ExtendedAssignOpRule.
- *
- * Every line here mixes an array with something that is not an array, which is exactly what the
- * check claims to report.
  */
 final class ArrayInCombinationWithNonArrayFixtures
 {
@@ -36,6 +33,18 @@ final class ArrayInCombinationWithNonArrayFixtures
     public function arrayComparedToNonEmptyArray(array $left, array $right): bool
     {
         return $left == $right;
+    }
+
+    /**
+     * @param array<int, string> $left
+     *
+     * @return array<int, string>
+     */
+    public function arrayAddedToInt(array $left, int $right): array
+    {
+        $left += $right;
+
+        return $left;
     }
 
     /**

--- a/tests/fixtures/Vpr8MatchFixture.php
+++ b/tests/fixtures/Vpr8MatchFixture.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace voku\PHPStan\Rules\Test\fixtures;
+
+final class Vpr8MatchFixture
+{
+    public function check(int $value): string
+    {
+        return match (true) {
+            4 > $value => 'small',
+            default => 'big',
+        };
+    }
+}

--- a/tests/fixtures/Vpr8SwitchFixture.php
+++ b/tests/fixtures/Vpr8SwitchFixture.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace voku\PHPStan\Rules\Test\fixtures;
+
+final class Vpr8SwitchFixture
+{
+    public function check(int $value): string
+    {
+        switch (true) {
+            case 4 > $value:
+                return 'small';
+            default:
+                return 'big';
+        }
+    }
+}

--- a/tests/fixtures/Vpr8TernaryFixture.php
+++ b/tests/fixtures/Vpr8TernaryFixture.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace voku\PHPStan\Rules\Test\fixtures;
+
+final class Vpr8TernaryFixture
+{
+    public function check(int $value): string
+    {
+        return 4 > $value ? 'small' : 'big';
+    }
+}


### PR DESCRIPTION
## Summary

This is the first focused implementation slice from #70.

### VPR-8 — propagate `checkYodaConditions`

- propagate the existing flag into ternary, match and switch rules;
- preserve the legacy positional constructor order of `IfConditionMatchRule` and `IfConditionSwitchCaseRule`;
- wire the flag through `rules.neon` with named arguments;
- cover both flag states and pin the legacy constructor positions.

### VPR-2 — repair the unreachable array/non-array branch

- replace the `VerbosityLevel::typeOnly()` / `non-empty-array` string predicate with PHPStan's trinary `$type->isArray()->no()` result;
- report only definite non-array operands;
- keep array and `non-empty-array` combinations silent;
- turn the existing defect-pinning test into the executable post-fix behavior contract, including `+=`.

## Scope

Intentionally does **not** include VPR-3/4/5/6/7. Those need separate evidence/semantics and should not make this repair slice harder to review.

## Validation

GitHub Actions run #300 is green across PHP 7.4, 8.0, 8.1, 8.2, 8.3 and 8.4. The PHP 7.4 job also runs PHPStan and is green.

Refs #70