### PR TITLE
Pin the null-coalesce false-positive boundary

### DIFF
--- a/.agent-loop/todo/cards/VPR-7.md
+++ b/.agent-loop/todo/cards/VPR-7.md
@@ -1,12 +1,18 @@
 # VPR-7: Re-evaluate the unconditional Coalesce skip
 
 - **Ticket:** VPR-7
-- **Lane:** BACKLOG
-- **Status:** todo
+- **Lane:** VERIFY
+- **Status:** verify
 - **Created:** 2026-08-27T00:34:41+00:00
-- **Updated:** 2026-08-27T00:34:41+00:00
-- **Summary:** IfConditionHelper skips BinaryOp\Coalesce in processObjectMethodUsageForComparison, in processObjectComparison and in processNestedObjectComparisons. PHPStan 2.x meanwhile ships an unnecessaryNullCoalesce feature toggle that reports a ?? whose left-hand side is never null.
+- **Updated:** 2026-08-27T09:10:00+00:00
+- **Summary:** Measured and rejected as a production change. The Coalesce skip is load-bearing: issue #18 is the historical reproduction showing that a class configured in `classesNotInIfConditions` must remain valid on the left side of `??`. Regression coverage now pins both a nullable object and an optional array-offset case. PHPStan 2.2 already owns null-coalesce diagnostics through its level-1 `NullCoalesceRule`, including the `unnecessaryNullCoalesce` feature path, so adding a second voku rule would duplicate native responsibility.
+- **Next:** Keep the existing Coalesce guards. No production change is required unless a future regression can narrow the skip without reintroducing #18.
+- **Validation:** php vendor/bin/phpunit -c phpunit.xml --filter Vpr7CoalesceSkipTest
 - **Format version:** 1
 
-## Agent Task Brief
-Establish why the skip exists (probably false positives on $foo['x'] ?? null), write the fixture that made it necessary, and check whether the skip is now wider than it needs to be.
+## Decision evidence
+
+- `voku/phpstan-rules#18` records the concrete false positive that originally required the skip: a configured object used as `$maybeThing ?? new Thing()` was incorrectly treated as an invalid condition.
+- `IfConditionHelper` excludes `BinaryOp\\Coalesce` from the object-comparison paths; those guards match the boundary demonstrated by #18.
+- PHPStan 2.2 registers `PHPStan\\Rules\\Variables\\NullCoalesceRule` at level 1 and owns both ordinary null-coalesce diagnostics and the `nullCoalesce.unnecessary` feature-toggle diagnostic.
+- The new fixture proves that configured nullable objects and optional object-valued array offsets stay silent in this extension.

--- a/tests/Vpr7CoalesceSkipTest.php
+++ b/tests/Vpr7CoalesceSkipTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace voku\PHPStan\Rules\Test;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use voku\PHPStan\Rules\IfConditionRule;
+
+/**
+ * Regression coverage for VPR-7 / issue #18.
+ *
+ * Coalesce is not a comparison or truthiness test. A class configured through
+ * classesNotInIfConditions must therefore remain usable on the left side of ??, including an
+ * optional array offset. Removing the Coalesce guards in IfConditionHelper would reintroduce the
+ * false positive reported in #18.
+ *
+ * @extends RuleTestCase<IfConditionRule>
+ */
+final class Vpr7CoalesceSkipTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new IfConditionRule([\stdClass::class], $this->createReflectionProvider(), false, false);
+    }
+
+    public function testConfiguredObjectsRemainValidWithNullCoalesce(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/fixtures/Vpr7CoalesceSkipFixture.php'],
+            []
+        );
+    }
+}

--- a/tests/fixtures/Vpr7CoalesceSkipFixture.php
+++ b/tests/fixtures/Vpr7CoalesceSkipFixture.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace voku\PHPStan\Rules\Test\fixtures;
+
+final class Vpr7CoalesceSkipFixture
+{
+    public function nullableObject(?\stdClass $value): \stdClass
+    {
+        return $value ?? new \stdClass();
+    }
+
+    /**
+     * @param array{value?: \stdClass} $values
+     */
+    public function optionalArrayOffset(array $values): \stdClass
+    {
+        return $values['value'] ?? new \stdClass();
+    }
+}


### PR DESCRIPTION
## Summary

Resolve VPR-7 from #70 as an evidence-backed **no production change**.

- preserve the existing `BinaryOp\Coalesce` guards in `IfConditionHelper`;
- add regression coverage for the historical #18 shape with a configured nullable object;
- also pin the optional array-offset case;
- record the decision on the VPR-7 card.

## Why no new rule

Issue #18 is the concrete false-positive reproduction that required the skip: `classesNotInIfConditions` must not make `$maybeThing ?? new Thing()` invalid.

PHPStan 2.2 already registers `PHPStan\Rules\Variables\NullCoalesceRule` at level 1 and owns the null-coalesce diagnostics, including the `nullCoalesce.unnecessary` path behind its feature toggle. Adding a parallel extension rule would duplicate native responsibility rather than narrow a proven gap.

## Validation

GitHub Actions run #301 is green across PHP 7.4, 8.0, 8.1, 8.2, 8.3 and 8.4. The PHP 7.4 job also runs PHPStan and is green.

Refs #70
Refs #18