### PR TITLE
Add opt-in loose in_array comparison rule

### DIFF
--- a/.agent-loop/todo/cards/VPR-6.md
+++ b/.agent-loop/todo/cards/VPR-6.md
@@ -1,12 +1,19 @@
 # VPR-6: New rule candidate: loose in_array()/array_search() without $strict
 
 - **Ticket:** VPR-6
-- **Lane:** BACKLOG
-- **Status:** todo
+- **Lane:** VERIFY
+- **Status:** verify
 - **Created:** 2026-08-27T00:34:41+00:00
-- **Updated:** 2026-08-27T00:34:41+00:00
-- **Summary:** in_array($needle, $haystack) without the third argument is the same PHP 8 comparison hazard the package already covers for ==, and it is the form that silently changed behaviour. PHPStan only covers the impossible-haystack case, through ImpossibleInArrayHaystackFiniteTypesRule, and only behind the finiteTypesInHaystack feature toggle (off by default, on in bleedingEdge).
+- **Updated:** 2026-08-27T09:31:00+00:00
+- **Summary:** Implemented as an opt-in rule only. It reports the PHP 7 -> PHP 8 loose-comparison hazard for global `in_array()` / `array_search()` when a definite int/float is compared with a definite non-numeric string through a non-constant typed haystack. Constant haystacks, numeric-string, mixed/union types, unknown strict flags, namespaced unqualified calls and strict mode remain silent. Named arguments are resolved by parameter name on PHP 8+.
+- **Next:** Keep the rule out of `rules.neon`; merge only after the PHP 7.4-8.4 matrix proves the positive, false-positive and named-argument fixtures.
+- **Validation:** php vendor/bin/phpunit -c phpunit.xml --filter InArrayLooseComparisonRuleTest
 - **Format version:** 1
 
-## Agent Task Brief
-Evaluate a rule that reports a loose in_array()/array_search() when the needle and the haystack value types can compare surprisingly under PHP 8 semantics, in the same spirit as the existing 'Possible insane comparison' message. Keep it out of rules.neon until it has a false-positive fixture.
+## Decision evidence
+
+- PHPStan's own finite-haystack rules target constant/finite haystacks; this rule explicitly declines constant arrays rather than duplicating that surface.
+- The positive fixture uses parameter-typed non-constant haystacks and covers `in_array()`, `array_search()`, omitted strict mode, explicit `false`, int/string in both directions and float/string.
+- The false-positive fixture covers strict mode, same scalar families, numeric-string in both directions, unknown strict mode, mixed and union operands, constant haystacks and namespace-shadowable calls.
+- PHP-8-only coverage proves named arguments are resolved semantically rather than by raw argument order, while the general fixture remains parseable on PHP 7.4.
+- Every emitted diagnostic is pinned to identifier `voku.FuncCall`.

--- a/README.md
+++ b/README.md
@@ -107,6 +107,17 @@ rules:
     - voku\PHPStan\Rules\DisallowedCallMethodOnNullRule
 ```
 
+### InArrayLooseComparisonRule
+
+This opt-in rule detects the PHP 7 -> PHP 8 loose-comparison hazard in `in_array()` and `array_search()` when a definite int/float is compared with a definite non-numeric string through a typed, non-constant haystack.
+
+It is deliberately **not** part of `rules.neon`: strict mode, numeric strings, mixed/union types, unknown strict flags and constant haystacks remain outside its reporting surface.
+
+```neon
+rules:
+    - voku\PHPStan\Rules\InArrayLooseComparisonRule
+```
+
 ### Support
 
 For support and donations please visit [Github](https://github.com/voku/phpstan-rules/) | [Issues](https://github.com/voku/phpstan-rules/issues) | [PayPal](https://paypal.me/moelleken) | [Patreon](https://www.patreon.com/voku).

--- a/src/voku/PHPStan/Rules/InArrayLooseComparisonRule.php
+++ b/src/voku/PHPStan/Rules/InArrayLooseComparisonRule.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+
+namespace voku\PHPStan\Rules;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Type\Type;
+use PHPStan\Type\VerbosityLevel;
+use function sprintf;
+
+/**
+ * Reports the PHP 7 -> PHP 8 loose-comparison hazard for in_array()/array_search().
+ *
+ * The rule is deliberately opt-in and fail-open:
+ * - only global built-ins are considered;
+ * - constant haystacks stay with PHPStan's native array rules;
+ * - unknown, union, mixed and unknown-strict cases stay silent;
+ * - numeric-string comparisons stay silent because their loose result did not change in PHP 8.
+ *
+ * @implements Rule<\PhpParser\Node\Expr\FuncCall>
+ */
+final class InArrayLooseComparisonRule implements Rule
+{
+    /**
+     * @var array<string, true>
+     */
+    private const FUNCTIONS = [
+        'array_search' => true,
+        'in_array' => true,
+    ];
+
+    public function getNodeType(): string
+    {
+        return \PhpParser\Node\Expr\FuncCall::class;
+    }
+
+    /**
+     * @param \PhpParser\Node\Expr\FuncCall $node
+     *
+     * @return array<int, \PHPStan\Rules\RuleError>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (!$node->name instanceof Node\Name) {
+            return [];
+        }
+
+        if (!$node->name->isFullyQualified() && $scope->getNamespace() !== null) {
+            return [];
+        }
+
+        $functionName = \strtolower($node->name->toString());
+        if (!isset(self::FUNCTIONS[$functionName])) {
+            return [];
+        }
+
+        $arguments = $this->resolveArguments($node->getArgs());
+        if ($arguments === null) {
+            return [];
+        }
+
+        if ($arguments['strict'] !== null && !$scope->getType($arguments['strict']->value)->isFalse()->yes()) {
+            return [];
+        }
+
+        $needleType = $scope->getType($arguments['needle']->value);
+        $haystackType = $scope->getType($arguments['haystack']->value);
+
+        if (!$haystackType->isArray()->yes()) {
+            return [];
+        }
+
+        if ($haystackType->getConstantArrays() !== []) {
+            return [];
+        }
+
+        $valueType = $haystackType->getIterableValueType();
+        if (!$this->isPhp8ComparisonHazard($needleType, $valueType)) {
+            return [];
+        }
+
+        return [
+            IfConditionHelper::buildErrorMessage(
+                $node,
+                sprintf(
+                    'Possible insane comparison between %s and %s. Use strict mode e.g. `%s($needle, $haystack, true)`.',
+                    $needleType->describe(VerbosityLevel::value()),
+                    $valueType->describe(VerbosityLevel::value()),
+                    $functionName
+                ),
+                $node->getStartLine()
+            ),
+        ];
+    }
+
+    /**
+     * @param array<int, \PhpParser\Node\Arg> $args
+     *
+     * @return array{needle: \PhpParser\Node\Arg, haystack: \PhpParser\Node\Arg, strict: \PhpParser\Node\Arg|null}|null
+     */
+    private function resolveArguments(array $args): ?array
+    {
+        if (\count($args) < 2 || \count($args) > 3) {
+            return null;
+        }
+
+        /** @var array{needle: \PhpParser\Node\Arg|null, haystack: \PhpParser\Node\Arg|null, strict: \PhpParser\Node\Arg|null} $resolved */
+        $resolved = [
+            'needle' => null,
+            'haystack' => null,
+            'strict' => null,
+        ];
+        $positionNames = ['needle', 'haystack', 'strict'];
+        $position = 0;
+
+        foreach ($args as $arg) {
+            if ($arg->unpack) {
+                return null;
+            }
+
+            if ($arg->name !== null) {
+                $name = $arg->name->toString();
+                if (!\array_key_exists($name, $resolved) || $resolved[$name] !== null) {
+                    return null;
+                }
+
+                $resolved[$name] = $arg;
+
+                continue;
+            }
+
+            while ($position < 3 && $resolved[$positionNames[$position]] !== null) {
+                ++$position;
+            }
+
+            if ($position >= 3) {
+                return null;
+            }
+
+            $resolved[$positionNames[$position]] = $arg;
+            ++$position;
+        }
+
+        if (!$resolved['needle'] instanceof Node\Arg || !$resolved['haystack'] instanceof Node\Arg) {
+            return null;
+        }
+
+        return [
+            'needle' => $resolved['needle'],
+            'haystack' => $resolved['haystack'],
+            'strict' => $resolved['strict'],
+        ];
+    }
+
+    private function isPhp8ComparisonHazard(Type $needleType, Type $valueType): bool
+    {
+        if ($this->isNonNumericString($needleType) && $this->isIntegerOrFloat($valueType)) {
+            return true;
+        }
+
+        return $this->isIntegerOrFloat($needleType) && $this->isNonNumericString($valueType);
+    }
+
+    private function isIntegerOrFloat(Type $type): bool
+    {
+        return $type->isInteger()->yes() || $type->isFloat()->yes();
+    }
+
+    private function isNonNumericString(Type $type): bool
+    {
+        return $type->isString()->yes() && !$type->isNumericString()->yes();
+    }
+}

--- a/tests/InArrayLooseComparisonRuleTest.php
+++ b/tests/InArrayLooseComparisonRuleTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace voku\PHPStan\Rules\Test;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use voku\PHPStan\Rules\InArrayLooseComparisonRule;
+
+/**
+ * @extends RuleTestCase<InArrayLooseComparisonRule>
+ */
+final class InArrayLooseComparisonRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new InArrayLooseComparisonRule();
+    }
+
+    public function testPhp8LooseComparisonHazardsAreReported(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/fixtures/InArrayLooseComparisonFixtures.php'],
+            [
+                [
+                    'FuncCall: Possible insane comparison between int and string. Use strict mode e.g. `in_array($needle, $haystack, true)`.',
+                    14,
+                ],
+                [
+                    'FuncCall: Possible insane comparison between string and int. Use strict mode e.g. `in_array($needle, $haystack, true)`.',
+                    22,
+                ],
+                [
+                    'FuncCall: Possible insane comparison between int and string. Use strict mode e.g. `in_array($needle, $haystack, true)`.',
+                    30,
+                ],
+                [
+                    'FuncCall: Possible insane comparison between int and string. Use strict mode e.g. `array_search($needle, $haystack, true)`.',
+                    40,
+                ],
+                [
+                    'FuncCall: Possible insane comparison between float and string. Use strict mode e.g. `in_array($needle, $haystack, true)`.',
+                    48,
+                ],
+            ]
+        );
+    }
+
+    public function testNonHazardsStaySilent(): void
+    {
+        $this->analyse([__DIR__ . '/fixtures/InArrayLooseComparisonValidFixtures.php'], []);
+    }
+
+    public function testIdentifierIsStable(): void
+    {
+        $errors = $this->gatherAnalyserErrors([__DIR__ . '/fixtures/InArrayLooseComparisonFixtures.php']);
+
+        static::assertNotSame([], $errors);
+        foreach ($errors as $error) {
+            static::assertSame('voku.FuncCall', $error->getIdentifier());
+        }
+    }
+
+    /**
+     * @requires PHP 8.0
+     */
+    public function testNamedArgumentsAreResolvedByName(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/fixtures/InArrayLooseComparisonNamedArgumentsFixtures.php'],
+            [
+                [
+                    'FuncCall: Possible insane comparison between int and string. Use strict mode e.g. `in_array($needle, $haystack, true)`.',
+                    14,
+                ],
+            ]
+        );
+    }
+}

--- a/tests/RulesNeonRegistrationTest.php
+++ b/tests/RulesNeonRegistrationTest.php
@@ -18,6 +18,7 @@ use voku\PHPStan\Rules\IfConditionMatchRule;
 use voku\PHPStan\Rules\IfConditionRule;
 use voku\PHPStan\Rules\IfConditionSwitchCaseRule;
 use voku\PHPStan\Rules\IfConditionTernaryOperatorRule;
+use voku\PHPStan\Rules\InArrayLooseComparisonRule;
 use voku\PHPStan\Rules\WrongCastRule;
 
 /**
@@ -60,6 +61,7 @@ final class RulesNeonRegistrationTest extends PHPStanTestCase
      */
     private const OPT_IN_RULES = [
         DisallowedCallMethodOnNullRule::class,
+        InArrayLooseComparisonRule::class,
     ];
 
     /**

--- a/tests/fixtures/InArrayLooseComparisonFixtures.php
+++ b/tests/fixtures/InArrayLooseComparisonFixtures.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace voku\PHPStan\Rules\Test\fixtures;
+
+final class InArrayLooseComparisonFixtures
+{
+    /**
+     * @param array<int, string> $haystack
+     */
+    public function intNeedleInStringHaystack(int $needle, array $haystack): bool
+    {
+        return \in_array($needle, $haystack);
+    }
+
+    /**
+     * @param array<int, int> $haystack
+     */
+    public function stringNeedleInIntHaystack(string $needle, array $haystack): bool
+    {
+        return \in_array($needle, $haystack);
+    }
+
+    /**
+     * @param array<int, string> $haystack
+     */
+    public function explicitFalse(int $needle, array $haystack): bool
+    {
+        return \in_array($needle, $haystack, false);
+    }
+
+    /**
+     * @param array<int, string> $haystack
+     *
+     * @return int|false
+     */
+    public function arraySearch(int $needle, array $haystack)
+    {
+        return \array_search($needle, $haystack);
+    }
+
+    /**
+     * @param array<int, string> $haystack
+     */
+    public function floatNeedle(float $needle, array $haystack): bool
+    {
+        return \in_array($needle, $haystack);
+    }
+}

--- a/tests/fixtures/InArrayLooseComparisonNamedArgumentsFixtures.php
+++ b/tests/fixtures/InArrayLooseComparisonNamedArgumentsFixtures.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace voku\PHPStan\Rules\Test\fixtures;
+
+final class InArrayLooseComparisonNamedArgumentsFixtures
+{
+    /**
+     * @param array<int, string> $haystack
+     */
+    public function reordered(int $needle, array $haystack): bool
+    {
+        return \in_array(haystack: $haystack, needle: $needle, strict: false);
+    }
+
+    /**
+     * @param array<int, string> $haystack
+     */
+    public function strict(int $needle, array $haystack): bool
+    {
+        return \in_array(haystack: $haystack, needle: $needle, strict: true);
+    }
+}

--- a/tests/fixtures/InArrayLooseComparisonValidFixtures.php
+++ b/tests/fixtures/InArrayLooseComparisonValidFixtures.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace voku\PHPStan\Rules\Test\fixtures;
+
+final class InArrayLooseComparisonValidFixtures
+{
+    /**
+     * @param array<int, string> $haystack
+     */
+    public function strictMode(int $needle, array $haystack): bool
+    {
+        return \in_array($needle, $haystack, true);
+    }
+
+    /**
+     * @param array<int, string> $haystack
+     */
+    public function stringInStrings(string $needle, array $haystack): bool
+    {
+        return \in_array($needle, $haystack);
+    }
+
+    /**
+     * @param array<int, int> $haystack
+     */
+    public function intInInts(int $needle, array $haystack): bool
+    {
+        return \in_array($needle, $haystack);
+    }
+
+    /**
+     * @param numeric-string $needle
+     * @param array<int, int> $haystack
+     */
+    public function numericStringInInts(string $needle, array $haystack): bool
+    {
+        return \in_array($needle, $haystack);
+    }
+
+    /**
+     * @param array<int, numeric-string> $haystack
+     */
+    public function intInNumericStrings(int $needle, array $haystack): bool
+    {
+        return \in_array($needle, $haystack);
+    }
+
+    /**
+     * @param array<int, string> $haystack
+     */
+    public function unknownStrict(int $needle, array $haystack, bool $strict): bool
+    {
+        return \in_array($needle, $haystack, $strict);
+    }
+
+    /**
+     * @param array<int, mixed> $haystack
+     */
+    public function mixedHaystack(int $needle, array $haystack): bool
+    {
+        return \in_array($needle, $haystack);
+    }
+
+    /**
+     * @param int|string $needle
+     * @param array<int, string> $haystack
+     */
+    public function unionNeedle($needle, array $haystack): bool
+    {
+        return \in_array($needle, $haystack);
+    }
+
+    public function constantHaystack(int $needle): bool
+    {
+        return \in_array($needle, ['foo', 'bar']);
+    }
+
+    /**
+     * An unqualified call in a namespace may resolve to a local function, so the rule stays silent.
+     *
+     * @param array<int, string> $haystack
+     */
+    public function namespacedUnqualifiedCall(int $needle, array $haystack): bool
+    {
+        return in_array($needle, $haystack);
+    }
+}


### PR DESCRIPTION
## Summary

Resolve VPR-6 from #70 with a deliberately narrow **opt-in** rule.

- add `InArrayLooseComparisonRule` for global `in_array()` / `array_search()` calls where PHP 7 -> PHP 8 loose-comparison semantics can surprise (`int|float` vs non-numeric `string`);
- keep the rule out of `rules.neon` and classify it explicitly as opt-in;
- leave constant haystacks to PHPStan's native finite/constant-array analysis;
- fail open for mixed/union operands, numeric strings, unknown `$strict`, namespace-shadowable unqualified calls and argument unpacking;
- resolve PHP 8 named arguments by semantic parameter name instead of raw argument order;
- pin positive cases, false-positive cases and the `voku.FuncCall` identifier;
- keep PHP-8-only syntax in a separate fixture so PHP 7.4 can parse the general suite.

## Validation

The PR stays draft until the full PHP 7.4–8.4 matrix is green. PHPStan on the PHP 7.4 job is part of the acceptance signal.

Refs #70