### PR TITLE
Make trait-context divergence executable

### DIFF
--- a/tests/TraitContextEvidenceTest.php
+++ b/tests/TraitContextEvidenceTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace voku\PHPStan\Rules\Test;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use voku\PHPStan\Rules\IfConditionRule;
+
+/**
+ * Executable VPR-4 evidence for the current trait boundary.
+ *
+ * The same source expression is analysed in each using-class context. Two int consumers therefore
+ * reproduce the same comparison findings on the same trait line, while a string consumer produces
+ * different extension advice from that line. #74 owns changing this behavior to contextual trait
+ * deferral; this test makes the pre-fix divergence reproducible instead of leaving it in prose.
+ *
+ * @extends RuleTestCase<IfConditionRule>
+ */
+final class TraitContextEvidenceTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new IfConditionRule([], $this->createReflectionProvider());
+    }
+
+    public function testTraitComparisonIsPublishedPerUsingClassContext(): void
+    {
+        $fixture = __DIR__ . '/fixtures/TraitContext/';
+        $errors = $this->gatherAnalyserErrors([
+            $fixture . 'LooseComparisonTrait.php',
+            $fixture . 'IntTraitConsumerOne.php',
+            $fixture . 'IntTraitConsumerTwo.php',
+            $fixture . 'StringTraitConsumer.php',
+        ]);
+
+        $intGenericLines = [];
+        $intAdviceLines = [];
+        $stringAdviceLines = [];
+
+        foreach ($errors as $error) {
+            $message = $error->getMessage();
+
+            if (\strpos($message, "Condition between '' and int are falsy") !== false) {
+                $intGenericLines[] = $error->getLine();
+            }
+
+            if (\strpos($message, 'double negative integer conditions') !== false) {
+                $intAdviceLines[] = $error->getLine();
+            }
+
+            if (\strpos($message, 'double negative string conditions') !== false) {
+                $stringAdviceLines[] = $error->getLine();
+            }
+        }
+
+        static::assertGreaterThanOrEqual(
+            2,
+            \count($intGenericLines),
+            'Two int consumers should expose the current per-use duplicate generic finding.'
+        );
+        static::assertCount(
+            1,
+            \array_unique($intGenericLines),
+            'The duplicate findings must originate from the same trait expression.'
+        );
+        static::assertGreaterThanOrEqual(
+            2,
+            \count($intAdviceLines),
+            'The extension-specific int advice is currently published per int consumer too.'
+        );
+        static::assertNotSame(
+            [],
+            $stringAdviceLines,
+            'A string consumer must demonstrate that the same trait expression is analysed in a different type context.'
+        );
+        static::assertSame(
+            $intGenericLines[0],
+            $stringAdviceLines[0],
+            'Context-dependent diagnostics should point to the same source expression in the trait.'
+        );
+    }
+}

--- a/tests/TraitContextEvidenceTest.php
+++ b/tests/TraitContextEvidenceTest.php
@@ -33,9 +33,9 @@ final class TraitContextEvidenceTest extends RuleTestCase
 
     public function testTraitComparisonIsPublishedPerUsingClassContext(): void
     {
-        $intConsumerOneMessages = $this->traitMessagesByLine(self::INT_CONSUMER_ONE_FIXTURE);
-        $intConsumerTwoMessages = $this->traitMessagesByLine(self::INT_CONSUMER_TWO_FIXTURE);
-        $stringConsumerMessages = $this->traitMessagesByLine(self::STRING_CONSUMER_FIXTURE);
+        $intConsumerOneMessages = $this->messagesByLineForConsumer(self::INT_CONSUMER_ONE_FIXTURE);
+        $intConsumerTwoMessages = $this->messagesByLineForConsumer(self::INT_CONSUMER_TWO_FIXTURE);
+        $stringConsumerMessages = $this->messagesByLineForConsumer(self::STRING_CONSUMER_FIXTURE);
 
         self::assertMessageContains(
             $intConsumerOneMessages[self::TRAIT_COMPARISON_LINE] ?? [],
@@ -68,15 +68,11 @@ final class TraitContextEvidenceTest extends RuleTestCase
     /**
      * @return array<int, array<int, string>>
      */
-    private function traitMessagesByLine(string $consumerFixture): array
+    private function messagesByLineForConsumer(string $consumerFixture): array
     {
         $messages = [];
 
         foreach ($this->gatherAnalyserErrors([self::TRAIT_FIXTURE, $consumerFixture]) as $error) {
-            if ($error->getFilePath() !== self::TRAIT_FIXTURE) {
-                continue;
-            }
-
             $messages[$error->getLine()][] = $error->getMessage();
         }
 

--- a/tests/TraitContextEvidenceTest.php
+++ b/tests/TraitContextEvidenceTest.php
@@ -11,15 +11,21 @@ use voku\PHPStan\Rules\IfConditionRule;
 /**
  * Executable VPR-4 evidence for the current trait boundary.
  *
- * The same source expression is analysed in each using-class context. Two int consumers therefore
- * reproduce the same comparison findings on the same trait line, while a string consumer produces
- * different extension advice from that line. #74 owns changing this behavior to contextual trait
- * deferral; this test makes the pre-fix divergence reproducible instead of leaving it in prose.
+ * The same source expression is analysed independently in each using-class context. Two int consumers
+ * therefore reproduce the same comparison findings on the same trait line, while a string consumer
+ * produces different extension advice from that line. #74 owns changing this behavior to contextual
+ * trait deferral; this test makes the pre-fix divergence reproducible instead of leaving it in prose.
  *
  * @extends RuleTestCase<IfConditionRule>
  */
 final class TraitContextEvidenceTest extends RuleTestCase
 {
+    private const TRAIT_FIXTURE = __DIR__ . '/fixtures/TraitContext/LooseComparisonTrait.php';
+    private const INT_CONSUMER_ONE_FIXTURE = __DIR__ . '/fixtures/TraitContext/IntTraitConsumerOne.php';
+    private const INT_CONSUMER_TWO_FIXTURE = __DIR__ . '/fixtures/TraitContext/IntTraitConsumerTwo.php';
+    private const STRING_CONSUMER_FIXTURE = __DIR__ . '/fixtures/TraitContext/StringTraitConsumer.php';
+    private const TRAIT_COMPARISON_LINE = 11;
+
     protected function getRule(): Rule
     {
         return new IfConditionRule([], $this->createReflectionProvider());
@@ -27,58 +33,81 @@ final class TraitContextEvidenceTest extends RuleTestCase
 
     public function testTraitComparisonIsPublishedPerUsingClassContext(): void
     {
-        $fixture = __DIR__ . '/fixtures/TraitContext/';
-        $errors = $this->gatherAnalyserErrors([
-            $fixture . 'LooseComparisonTrait.php',
-            $fixture . 'IntTraitConsumerOne.php',
-            $fixture . 'IntTraitConsumerTwo.php',
-            $fixture . 'StringTraitConsumer.php',
-        ]);
+        $intConsumerOneMessages = $this->traitMessagesByLine(self::INT_CONSUMER_ONE_FIXTURE);
+        $intConsumerTwoMessages = $this->traitMessagesByLine(self::INT_CONSUMER_TWO_FIXTURE);
+        $stringConsumerMessages = $this->traitMessagesByLine(self::STRING_CONSUMER_FIXTURE);
 
-        $intGenericLines = [];
-        $intAdviceLines = [];
-        $stringAdviceLines = [];
+        self::assertMessageContains(
+            $intConsumerOneMessages[self::TRAIT_COMPARISON_LINE] ?? [],
+            "Condition between '' and int are falsy"
+        );
+        self::assertMessageContains(
+            $intConsumerOneMessages[self::TRAIT_COMPARISON_LINE] ?? [],
+            'double negative integer conditions'
+        );
 
-        foreach ($errors as $error) {
-            $message = $error->getMessage();
+        self::assertMessageContains(
+            $intConsumerTwoMessages[self::TRAIT_COMPARISON_LINE] ?? [],
+            "Condition between '' and int are falsy"
+        );
+        self::assertMessageContains(
+            $intConsumerTwoMessages[self::TRAIT_COMPARISON_LINE] ?? [],
+            'double negative integer conditions'
+        );
 
-            if (\strpos($message, "Condition between '' and int are falsy") !== false) {
-                $intGenericLines[] = $error->getLine();
+        self::assertMessageContains(
+            $stringConsumerMessages[self::TRAIT_COMPARISON_LINE] ?? [],
+            'double negative string conditions'
+        );
+        self::assertNoMessageContains(
+            $stringConsumerMessages[self::TRAIT_COMPARISON_LINE] ?? [],
+            'double negative integer conditions'
+        );
+    }
+
+    /**
+     * @return array<int, array<int, string>>
+     */
+    private function traitMessagesByLine(string $consumerFixture): array
+    {
+        $messages = [];
+
+        foreach ($this->gatherAnalyserErrors([self::TRAIT_FIXTURE, $consumerFixture]) as $error) {
+            if ($error->getFilePath() !== self::TRAIT_FIXTURE) {
+                continue;
             }
 
-            if (\strpos($message, 'double negative integer conditions') !== false) {
-                $intAdviceLines[] = $error->getLine();
-            }
+            $messages[$error->getLine()][] = $error->getMessage();
+        }
 
-            if (\strpos($message, 'double negative string conditions') !== false) {
-                $stringAdviceLines[] = $error->getLine();
+        return $messages;
+    }
+
+    /**
+     * @param array<int, string> $messages
+     */
+    private static function assertMessageContains(array $messages, string $needle): void
+    {
+        foreach ($messages as $actualMessage) {
+            if (\strpos($actualMessage, $needle) !== false) {
+                static::assertTrue(true);
+
+                return;
             }
         }
 
-        static::assertGreaterThanOrEqual(
-            2,
-            \count($intGenericLines),
-            'Two int consumers should expose the current per-use duplicate generic finding.'
-        );
-        static::assertCount(
-            1,
-            \array_unique($intGenericLines),
-            'The duplicate findings must originate from the same trait expression.'
-        );
-        static::assertGreaterThanOrEqual(
-            2,
-            \count($intAdviceLines),
-            'The extension-specific int advice is currently published per int consumer too.'
-        );
-        static::assertNotSame(
-            [],
-            $stringAdviceLines,
-            'A string consumer must demonstrate that the same trait expression is analysed in a different type context.'
-        );
-        static::assertSame(
-            $intGenericLines[0],
-            $stringAdviceLines[0],
-            'Context-dependent diagnostics should point to the same source expression in the trait.'
-        );
+        static::fail('No trait diagnostic contained: ' . $needle);
+    }
+
+    /**
+     * @param array<int, string> $messages
+     */
+    private static function assertNoMessageContains(array $messages, string $needle): void
+    {
+        foreach ($messages as $actualMessage) {
+            static::assertStringNotContainsString($needle, $actualMessage);
+        }
+
+        static::assertTrue(true);
     }
 }

--- a/tests/fixtures/TraitContext/IntTraitConsumerOne.php
+++ b/tests/fixtures/TraitContext/IntTraitConsumerOne.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace voku\PHPStan\Rules\Test\fixtures\TraitContext;
+
+final class IntTraitConsumerOne
+{
+    use LooseComparisonTrait;
+
+    /** @var int */
+    private $value = 1;
+}

--- a/tests/fixtures/TraitContext/IntTraitConsumerTwo.php
+++ b/tests/fixtures/TraitContext/IntTraitConsumerTwo.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace voku\PHPStan\Rules\Test\fixtures\TraitContext;
+
+final class IntTraitConsumerTwo
+{
+    use LooseComparisonTrait;
+
+    /** @var int */
+    private $value = 2;
+}

--- a/tests/fixtures/TraitContext/LooseComparisonTrait.php
+++ b/tests/fixtures/TraitContext/LooseComparisonTrait.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace voku\PHPStan\Rules\Test\fixtures\TraitContext;
+
+trait LooseComparisonTrait
+{
+    public function hasValue(): bool
+    {
+        return $this->value != '';
+    }
+}

--- a/tests/fixtures/TraitContext/StringTraitConsumer.php
+++ b/tests/fixtures/TraitContext/StringTraitConsumer.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace voku\PHPStan\Rules\Test\fixtures\TraitContext;
+
+final class StringTraitConsumer
+{
+    use LooseComparisonTrait;
+
+    /** @var string */
+    private $value = 'value';
+}


### PR DESCRIPTION
## Summary

Close the remaining evidence gap in #70 / VPR-4 without pretending to solve the contextual trait-deferral work owned by #74.

- add a PSR-4-aligned trait fixture used by two int consumers and one string consumer;
- execute the real `IfConditionRule` through `RuleTestCase` across those using-class contexts;
- prove the current per-use duplicate behavior by requiring the same generic int finding more than once on the same trait source line;
- prove context sensitivity by requiring string-specific advice from that same source expression;
- make the current divergence executable so #74 has a reproducible pre-fix contract.

## Non-goal

This PR does **not** add `ConstantConditionInTraitHelper`/collector integration and does not change production diagnostics. #74 remains the owner for that semantic change and for the PHPStan-floor decision.

## Validation

Draft until the exact-head PHP 7.4–8.4 matrix and PHPStan job are green.

Refs #70
Refs #74

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for trait-based comparisons across multiple consuming classes.
  * Verified diagnostics are reported for each usage context.
  * Confirmed type-specific guidance differs appropriately for integer and string values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->