### PR TITLE
Defer trait comparison diagnostics across using-class contexts

### DIFF
--- a/rules.neon
+++ b/rules.neon
@@ -73,7 +73,24 @@ services:
 			reportAlwaysTrueInLastCondition: %reportAlwaysTrueInLastCondition%
 			treatPhpDocTypesAsCertain: %treatPhpDocTypesAsCertain%
 		tags:
-			- phpstan.rules.rule		
+			- phpstan.rules.rule
+
+	-
+		class: voku\PHPStan\Rules\TraitContextComparisonCollector
+		arguments:
+			classesNotInIfConditions: %voku.classesNotInIfConditions%
+			checkYodaConditions: %voku.checkYodaConditions%
+			checkForAssignments: %voku.checkForAssignments%
+			reportDuplicateNativeComparisons: %voku.reportDuplicateNativeComparisons%
+			reportAlwaysTrueInLastCondition: %reportAlwaysTrueInLastCondition%
+			treatPhpDocTypesAsCertain: %treatPhpDocTypesAsCertain%
+		tags:
+			- phpstan.collector
+
+	-
+		class: voku\PHPStan\Rules\TraitContextComparisonRule
+		tags:
+			- phpstan.rules.rule
 			
 	-
 		class: voku\PHPStan\Rules\IfConditionBasicRule

--- a/src/voku/PHPStan/Rules/IfConditionRule.php
+++ b/src/voku/PHPStan/Rules/IfConditionRule.php
@@ -14,41 +14,10 @@ use PHPStan\Rules\Rule;
  */
 final class IfConditionRule implements Rule
 {
-
     /**
-     * @var array<int, class-string>
+     * @var IfConditionRuleDiagnostics
      */
-    private $classesNotInIfConditions;
-
-    /**
-     * @var bool
-     */
-    private $checkForAssignments;
-
-    /**
-     * @var bool
-     */
-    private $checkYodaConditions;
-
-    /**
-     * @var null|ReflectionProvider
-     */
-    private $reflectionProvider;
-
-    /**
-     * @var bool
-     */
-    private $reportDuplicateNativeComparisons;
-
-    /**
-     * @var bool
-     */
-    private $reportAlwaysTrueInLastCondition;
-
-    /**
-     * @var bool
-     */
-    private $treatPhpDocTypesAsCertain;
+    private $diagnostics;
 
     /**
      * @param array<int, class-string> $classesNotInIfConditions
@@ -56,26 +25,21 @@ final class IfConditionRule implements Rule
     public function __construct(
         array $classesNotInIfConditions = [],
         ?ReflectionProvider $reflectionProvider = null,
-        bool                $checkForAssignments = false,
-        bool                $checkYodaConditions = false,
-        bool                $reportDuplicateNativeComparisons = true,
-        bool                $reportAlwaysTrueInLastCondition = true,
-        bool                $treatPhpDocTypesAsCertain = true
-    )
-    {
-        $this->reflectionProvider = $reflectionProvider;
-
-        $this->classesNotInIfConditions = $classesNotInIfConditions;
-
-        $this->checkForAssignments = $checkForAssignments;
-
-        $this->checkYodaConditions = $checkYodaConditions;
-
-        $this->reportDuplicateNativeComparisons = $reportDuplicateNativeComparisons;
-
-        $this->reportAlwaysTrueInLastCondition = $reportAlwaysTrueInLastCondition;
-
-        $this->treatPhpDocTypesAsCertain = $treatPhpDocTypesAsCertain;
+        bool $checkForAssignments = false,
+        bool $checkYodaConditions = false,
+        bool $reportDuplicateNativeComparisons = true,
+        bool $reportAlwaysTrueInLastCondition = true,
+        bool $treatPhpDocTypesAsCertain = true
+    ) {
+        $this->diagnostics = new IfConditionRuleDiagnostics(
+            $classesNotInIfConditions,
+            $reflectionProvider,
+            $checkForAssignments,
+            $checkYodaConditions,
+            $reportDuplicateNativeComparisons,
+            $reportAlwaysTrueInLastCondition,
+            $treatPhpDocTypesAsCertain
+        );
     }
 
     public function getNodeType(): string
@@ -90,40 +54,10 @@ final class IfConditionRule implements Rule
      */
     public function processNode(Node $node, Scope $scope): array
     {
-        $leftType = $scope->getType($node->left);
-        $rightType = $scope->getType($node->right);
+        if ($scope->isInTrait()) {
+            return [];
+        }
 
-        $errors = [];
-        $errors = IfConditionHelper::processNodeHelper(
-            $leftType,
-            $rightType,
-            $node,
-            $errors,
-            $this->classesNotInIfConditions,
-            $node,
-            $this->reflectionProvider,
-            $this->checkForAssignments,
-            $this->checkYodaConditions
-        );
-        $errors = IfConditionHelper::processNodeHelper(
-            $rightType,
-            $leftType,
-            $node,
-            $errors,
-            $this->classesNotInIfConditions,
-            $node,
-            $this->reflectionProvider,
-            false,
-            false
-        );
-
-        return IfConditionDiagnosticPolicy::filterBinaryComparison(
-            $node,
-            $scope,
-            $errors,
-            $this->reportDuplicateNativeComparisons,
-            $this->reportAlwaysTrueInLastCondition,
-            $this->treatPhpDocTypesAsCertain
-        );
+        return $this->diagnostics->processNode($node, $scope);
     }
 }

--- a/src/voku/PHPStan/Rules/IfConditionRuleDiagnostics.php
+++ b/src/voku/PHPStan/Rules/IfConditionRuleDiagnostics.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace voku\PHPStan\Rules;
+
+use PhpParser\Node\Expr\BinaryOp;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Rules\RuleError;
+
+/**
+ * Shared diagnostic calculation for direct and trait-context analysis.
+ */
+final class IfConditionRuleDiagnostics
+{
+    /**
+     * @var array<int, class-string>
+     */
+    private $classesNotInIfConditions;
+
+    /**
+     * @var bool
+     */
+    private $checkForAssignments;
+
+    /**
+     * @var bool
+     */
+    private $checkYodaConditions;
+
+    /**
+     * @var null|ReflectionProvider
+     */
+    private $reflectionProvider;
+
+    /**
+     * @var bool
+     */
+    private $reportDuplicateNativeComparisons;
+
+    /**
+     * @var bool
+     */
+    private $reportAlwaysTrueInLastCondition;
+
+    /**
+     * @var bool
+     */
+    private $treatPhpDocTypesAsCertain;
+
+    /**
+     * @param array<int, class-string> $classesNotInIfConditions
+     */
+    public function __construct(
+        array $classesNotInIfConditions = [],
+        ?ReflectionProvider $reflectionProvider = null,
+        bool $checkForAssignments = false,
+        bool $checkYodaConditions = false,
+        bool $reportDuplicateNativeComparisons = true,
+        bool $reportAlwaysTrueInLastCondition = true,
+        bool $treatPhpDocTypesAsCertain = true
+    ) {
+        $this->classesNotInIfConditions = $classesNotInIfConditions;
+        $this->reflectionProvider = $reflectionProvider;
+        $this->checkForAssignments = $checkForAssignments;
+        $this->checkYodaConditions = $checkYodaConditions;
+        $this->reportDuplicateNativeComparisons = $reportDuplicateNativeComparisons;
+        $this->reportAlwaysTrueInLastCondition = $reportAlwaysTrueInLastCondition;
+        $this->treatPhpDocTypesAsCertain = $treatPhpDocTypesAsCertain;
+    }
+
+    /**
+     * @return array<int, RuleError>
+     */
+    public function processNode(BinaryOp $node, Scope $scope): array
+    {
+        $leftType = $scope->getType($node->left);
+        $rightType = $scope->getType($node->right);
+
+        $errors = [];
+        $errors = IfConditionHelper::processNodeHelper(
+            $leftType,
+            $rightType,
+            $node,
+            $errors,
+            $this->classesNotInIfConditions,
+            $node,
+            $this->reflectionProvider,
+            $this->checkForAssignments,
+            $this->checkYodaConditions
+        );
+        $errors = IfConditionHelper::processNodeHelper(
+            $rightType,
+            $leftType,
+            $node,
+            $errors,
+            $this->classesNotInIfConditions,
+            $node,
+            $this->reflectionProvider,
+            false,
+            false
+        );
+
+        return IfConditionDiagnosticPolicy::filterBinaryComparison(
+            $node,
+            $scope,
+            $errors,
+            $this->reportDuplicateNativeComparisons,
+            $this->reportAlwaysTrueInLastCondition,
+            $this->treatPhpDocTypesAsCertain
+        );
+    }
+}

--- a/src/voku/PHPStan/Rules/TraitContextComparisonCollector.php
+++ b/src/voku/PHPStan/Rules/TraitContextComparisonCollector.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace voku\PHPStan\Rules;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\BinaryOp;
+use PHPStan\Analyser\Scope;
+use PHPStan\Collectors\Collector;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Rules\LineRuleError;
+
+/**
+ * Collects IfConditionRule diagnostics for every using-class context of a trait expression.
+ *
+ * @implements Collector<BinaryOp, array{
+ *     string,
+ *     string,
+ *     string,
+ *     string,
+ *     array<int, array{string, null|string, int}>
+ * }>
+ */
+final class TraitContextComparisonCollector implements Collector
+{
+    /**
+     * @var IfConditionRuleDiagnostics
+     */
+    private $diagnostics;
+
+    /**
+     * @param array<int, class-string> $classesNotInIfConditions
+     */
+    public function __construct(
+        array $classesNotInIfConditions = [],
+        ?ReflectionProvider $reflectionProvider = null,
+        bool $checkForAssignments = false,
+        bool $checkYodaConditions = false,
+        bool $reportDuplicateNativeComparisons = true,
+        bool $reportAlwaysTrueInLastCondition = true,
+        bool $treatPhpDocTypesAsCertain = true
+    ) {
+        $this->diagnostics = new IfConditionRuleDiagnostics(
+            $classesNotInIfConditions,
+            $reflectionProvider,
+            $checkForAssignments,
+            $checkYodaConditions,
+            $reportDuplicateNativeComparisons,
+            $reportAlwaysTrueInLastCondition,
+            $treatPhpDocTypesAsCertain
+        );
+    }
+
+    public function getNodeType(): string
+    {
+        return BinaryOp::class;
+    }
+
+    /**
+     * @param BinaryOp $node
+     *
+     * @return array{
+     *     string,
+     *     string,
+     *     string,
+     *     string,
+     *     array<int, array{string, null|string, int}>
+     * }|null
+     */
+    public function processNode(Node $node, Scope $scope)
+    {
+        if (!$scope->isInTrait()) {
+            return null;
+        }
+
+        $traitReflection = $scope->getTraitReflection();
+        if ($traitReflection === null) {
+            return null;
+        }
+
+        $classReflection = $scope->getClassReflection();
+        $contextName = $classReflection !== null
+            ? $classReflection->getName()
+            : $scope->getFileDescription();
+
+        $serializedErrors = [];
+        foreach ($this->diagnostics->processNode($node, $scope) as $error) {
+            $serializedErrors[] = [
+                $error->getMessage(),
+                $error instanceof IdentifierRuleError ? $error->getIdentifier() : null,
+                $error instanceof LineRuleError ? $error->getLine() : $node->getStartLine(),
+            ];
+        }
+
+        return [
+            $traitReflection->getName(),
+            $contextName,
+            self::expressionKey($node),
+            $scope->getFile(),
+            $serializedErrors,
+        ];
+    }
+
+    private static function expressionKey(BinaryOp $node): string
+    {
+        return \implode(':', [
+            \get_class($node),
+            (string) $node->getStartLine(),
+            (string) $node->getAttribute('startFilePos', -1),
+            (string) $node->getAttribute('endFilePos', -1),
+        ]);
+    }
+}

--- a/src/voku/PHPStan/Rules/TraitContextComparisonCollector.php
+++ b/src/voku/PHPStan/Rules/TraitContextComparisonCollector.php
@@ -80,6 +80,11 @@ final class TraitContextComparisonCollector implements Collector
             return null;
         }
 
+        $traitFile = $traitReflection->getFileName();
+        if ($traitFile === null) {
+            return null;
+        }
+
         $classReflection = $scope->getClassReflection();
         $contextName = $classReflection !== null
             ? $classReflection->getName()
@@ -98,7 +103,7 @@ final class TraitContextComparisonCollector implements Collector
             $traitReflection->getName(),
             $contextName,
             self::expressionKey($node),
-            $scope->getFile(),
+            $traitFile,
             $serializedErrors,
         ];
     }

--- a/src/voku/PHPStan/Rules/TraitContextComparisonRule.php
+++ b/src/voku/PHPStan/Rules/TraitContextComparisonRule.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace voku\PHPStan\Rules;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Node\CollectedDataNode;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * Publishes only trait comparison diagnostics that are valid in every observed using-class context.
+ *
+ * @implements Rule<CollectedDataNode>
+ */
+final class TraitContextComparisonRule implements Rule
+{
+    public function getNodeType(): string
+    {
+        return CollectedDataNode::class;
+    }
+
+    /**
+     * @param CollectedDataNode $node
+     *
+     * @return array<int, \PHPStan\Rules\RuleError>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        /**
+         * @var array<string, array<string, array{
+         *     file: string,
+         *     contexts: array<string, array<string, array{string, null|string, int}>>
+         * }>> $expressions
+         */
+        $expressions = [];
+
+        foreach ($node->get(TraitContextComparisonCollector::class) as $fileData) {
+            foreach ($fileData as $data) {
+                $traitName = $data[0];
+                $contextName = $data[1];
+                $expressionKey = $data[2];
+                $file = $data[3];
+                $serializedErrors = $data[4];
+
+                if (!isset($expressions[$traitName][$expressionKey])) {
+                    $expressions[$traitName][$expressionKey] = [
+                        'file' => $file,
+                        'contexts' => [],
+                    ];
+                }
+
+                if (!isset($expressions[$traitName][$expressionKey]['contexts'][$contextName])) {
+                    $expressions[$traitName][$expressionKey]['contexts'][$contextName] = [];
+                }
+
+                foreach ($serializedErrors as $serializedError) {
+                    $errorKey = \serialize($serializedError);
+                    $expressions[$traitName][$expressionKey]['contexts'][$contextName][$errorKey] = $serializedError;
+                }
+            }
+        }
+
+        $errors = [];
+        foreach ($expressions as $traitExpressions) {
+            foreach ($traitExpressions as $expression) {
+                $commonErrors = null;
+
+                foreach ($expression['contexts'] as $contextErrors) {
+                    if ($commonErrors === null) {
+                        $commonErrors = $contextErrors;
+
+                        continue;
+                    }
+
+                    $commonErrors = \array_intersect_key($commonErrors, $contextErrors);
+                }
+
+                if ($commonErrors === null || $commonErrors === []) {
+                    continue;
+                }
+
+                \ksort($commonErrors);
+                foreach ($commonErrors as $serializedError) {
+                    $builder = RuleErrorBuilder::message($serializedError[0])
+                        ->line($serializedError[2])
+                        ->file($expression['file']);
+
+                    if ($serializedError[1] !== null) {
+                        $builder->identifier($serializedError[1]);
+                    }
+
+                    $errors[] = $builder->build();
+                }
+            }
+        }
+
+        return $errors;
+    }
+}

--- a/tests/RulesNeonRegistrationTest.php
+++ b/tests/RulesNeonRegistrationTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace voku\PHPStan\Rules\Test;
 
+use PHPStan\Collectors\Collector;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\PHPStanTestCase;
 use voku\PHPStan\Rules\DisallowedCallMethodOnNullRule;
@@ -19,6 +20,8 @@ use voku\PHPStan\Rules\IfConditionRule;
 use voku\PHPStan\Rules\IfConditionSwitchCaseRule;
 use voku\PHPStan\Rules\IfConditionTernaryOperatorRule;
 use voku\PHPStan\Rules\InArrayLooseComparisonRule;
+use voku\PHPStan\Rules\TraitContextComparisonCollector;
+use voku\PHPStan\Rules\TraitContextComparisonRule;
 use voku\PHPStan\Rules\WrongCastRule;
 
 /**
@@ -32,6 +35,7 @@ use voku\PHPStan\Rules\WrongCastRule;
 final class RulesNeonRegistrationTest extends PHPStanTestCase
 {
     private const PHPSTAN_RULE_TAG = 'phpstan.rules.rule';
+    private const PHPSTAN_COLLECTOR_TAG = 'phpstan.collector';
 
     /**
      * The rules a consumer gets by only including `rules.neon`.
@@ -50,7 +54,15 @@ final class RulesNeonRegistrationTest extends PHPStanTestCase
         IfConditionRule::class,
         IfConditionSwitchCaseRule::class,
         IfConditionTernaryOperatorRule::class,
+        TraitContextComparisonRule::class,
         WrongCastRule::class,
+    ];
+
+    /**
+     * @var array<int, class-string<Collector>>
+     */
+    private const SHIPPED_COLLECTORS = [
+        TraitContextComparisonCollector::class,
     ];
 
     /**
@@ -80,6 +92,16 @@ final class RulesNeonRegistrationTest extends PHPStanTestCase
         \sort($expected);
 
         $actual = $this->getRegisteredVokuRuleClasses();
+
+        static::assertSame($expected, $actual);
+    }
+
+    public function testRulesNeonRegistersExactlyTheShippedCollectors(): void
+    {
+        $expected = self::SHIPPED_COLLECTORS;
+        \sort($expected);
+
+        $actual = $this->getRegisteredVokuCollectorClasses();
 
         static::assertSame($expected, $actual);
     }
@@ -155,6 +177,25 @@ final class RulesNeonRegistrationTest extends PHPStanTestCase
         }
     }
 
+    public function testEveryRegisteredCollectorIsAnInstanceOfPhpStanCollector(): void
+    {
+        $services = self::getContainer()->getServicesByTag(self::PHPSTAN_COLLECTOR_TAG);
+
+        $vokuServices = \array_filter(
+            $services,
+            static function ($service): bool {
+                return \strpos(\get_class($service), 'voku\\PHPStan\\Rules\\') === 0;
+            }
+        );
+
+        static::assertCount(\count(self::SHIPPED_COLLECTORS), $vokuServices);
+
+        foreach ($vokuServices as $service) {
+            static::assertInstanceOf(Collector::class, $service);
+            static::assertNotSame('', $service->getNodeType());
+        }
+    }
+
     /**
      * @return array<int, class-string<Rule>>
      */
@@ -175,6 +216,29 @@ final class RulesNeonRegistrationTest extends PHPStanTestCase
         \sort($classNames);
 
         /** @var array<int, class-string<Rule>> $classNames */
+        return $classNames;
+    }
+
+    /**
+     * @return array<int, class-string<Collector>>
+     */
+    private function getRegisteredVokuCollectorClasses(): array
+    {
+        $classNames = [];
+
+        foreach (self::getContainer()->getServicesByTag(self::PHPSTAN_COLLECTOR_TAG) as $service) {
+            $className = \get_class($service);
+            if (\strpos($className, 'voku\\PHPStan\\Rules\\') !== 0) {
+                continue;
+            }
+
+            $classNames[] = $className;
+        }
+
+        $classNames = \array_values(\array_unique($classNames));
+        \sort($classNames);
+
+        /** @var array<int, class-string<Collector>> $classNames */
         return $classNames;
     }
 

--- a/tests/TraitContextEvidenceTest.php
+++ b/tests/TraitContextEvidenceTest.php
@@ -9,12 +9,10 @@ use PHPStan\Testing\RuleTestCase;
 use voku\PHPStan\Rules\IfConditionRule;
 
 /**
- * Executable VPR-4 evidence for the current trait boundary.
+ * Direct-rule regression for the trait deferral boundary owned by #74.
  *
- * The same source expression is analysed independently in each using-class context. Two int consumers
- * therefore reproduce the same comparison findings on the same trait line, while a string consumer
- * produces different extension advice from that line. #74 owns changing this behavior to contextual
- * trait deferral; this test makes the pre-fix divergence reproducible instead of leaving it in prose.
+ * Trait diagnostics are collected through TraitContextComparisonCollector and must not be published
+ * eagerly by IfConditionRule for one using-class context.
  *
  * @extends RuleTestCase<IfConditionRule>
  */
@@ -24,86 +22,24 @@ final class TraitContextEvidenceTest extends RuleTestCase
     private const INT_CONSUMER_ONE_FIXTURE = __DIR__ . '/fixtures/TraitContext/IntTraitConsumerOne.php';
     private const INT_CONSUMER_TWO_FIXTURE = __DIR__ . '/fixtures/TraitContext/IntTraitConsumerTwo.php';
     private const STRING_CONSUMER_FIXTURE = __DIR__ . '/fixtures/TraitContext/StringTraitConsumer.php';
-    private const TRAIT_COMPARISON_LINE = 11;
 
     protected function getRule(): Rule
     {
         return new IfConditionRule([], $this->createReflectionProvider());
     }
 
-    public function testTraitComparisonIsPublishedPerUsingClassContext(): void
+    public function testDirectRuleDefersEveryUsingClassContext(): void
     {
-        $intConsumerOneMessages = $this->messagesByLineForConsumer(self::INT_CONSUMER_ONE_FIXTURE);
-        $intConsumerTwoMessages = $this->messagesByLineForConsumer(self::INT_CONSUMER_TWO_FIXTURE);
-        $stringConsumerMessages = $this->messagesByLineForConsumer(self::STRING_CONSUMER_FIXTURE);
-
-        self::assertMessageContains(
-            $intConsumerOneMessages[self::TRAIT_COMPARISON_LINE] ?? [],
-            "Condition between '' and int are falsy"
-        );
-        self::assertMessageContains(
-            $intConsumerOneMessages[self::TRAIT_COMPARISON_LINE] ?? [],
-            'double negative integer conditions'
-        );
-
-        self::assertMessageContains(
-            $intConsumerTwoMessages[self::TRAIT_COMPARISON_LINE] ?? [],
-            "Condition between '' and int are falsy"
-        );
-        self::assertMessageContains(
-            $intConsumerTwoMessages[self::TRAIT_COMPARISON_LINE] ?? [],
-            'double negative integer conditions'
-        );
-
-        self::assertMessageContains(
-            $stringConsumerMessages[self::TRAIT_COMPARISON_LINE] ?? [],
-            'double negative string conditions'
-        );
-        self::assertNoMessageContains(
-            $stringConsumerMessages[self::TRAIT_COMPARISON_LINE] ?? [],
-            'double negative integer conditions'
-        );
-    }
-
-    /**
-     * @return array<int, array<int, string>>
-     */
-    private function messagesByLineForConsumer(string $consumerFixture): array
-    {
-        $messages = [];
-
-        foreach ($this->gatherAnalyserErrors([self::TRAIT_FIXTURE, $consumerFixture]) as $error) {
-            $messages[$error->getLine()][] = $error->getMessage();
+        foreach ([
+            self::INT_CONSUMER_ONE_FIXTURE,
+            self::INT_CONSUMER_TWO_FIXTURE,
+            self::STRING_CONSUMER_FIXTURE,
+        ] as $consumerFixture) {
+            static::assertSame(
+                [],
+                $this->gatherAnalyserErrors([self::TRAIT_FIXTURE, $consumerFixture]),
+                'IfConditionRule must not publish trait diagnostics before all using-class contexts are known.'
+            );
         }
-
-        return $messages;
-    }
-
-    /**
-     * @param array<int, string> $messages
-     */
-    private static function assertMessageContains(array $messages, string $needle): void
-    {
-        foreach ($messages as $actualMessage) {
-            if (\strpos($actualMessage, $needle) !== false) {
-                static::assertTrue(true);
-
-                return;
-            }
-        }
-
-        static::fail('No trait diagnostic contained: ' . $needle);
-    }
-
-    /**
-     * @param array<int, string> $messages
-     */
-    private static function assertNoMessageContains(array $messages, string $needle): void
-    {
-        foreach ($messages as $actualMessage) {
-            static::assertStringNotContainsString($needle, $actualMessage);
-        }
-
-        static::assertTrue(true);
     }
 }

--- a/tests/TraitContextIntegrationTest.php
+++ b/tests/TraitContextIntegrationTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace voku\PHPStan\Rules\Test;
 
 use PHPStan\Analyser\Analyser;
+use PHPStan\Analyser\AnalyserResultFinalizer;
 use PHPStan\Analyser\Error;
 use PHPStan\File\FileHelper;
 use PHPStan\Testing\PHPStanTestCase;
@@ -83,8 +84,14 @@ final class TraitContextIntegrationTest extends PHPStanTestCase
 
         /** @var Analyser $analyser */
         $analyser = self::getContainer()->getByType(Analyser::class);
+        /** @var AnalyserResultFinalizer $finalizer */
+        $finalizer = self::getContainer()->getByType(AnalyserResultFinalizer::class);
 
-        return $analyser->analyse($files)->getErrors();
+        return $finalizer->finalize(
+            $analyser->analyse($files, null, null, true),
+            false,
+            true
+        )->getErrors();
     }
 
     /**

--- a/tests/TraitContextIntegrationTest.php
+++ b/tests/TraitContextIntegrationTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace voku\PHPStan\Rules\Test;
+
+use PHPStan\Analyser\Analyser;
+use PHPStan\Analyser\Error;
+use PHPStan\File\FileHelper;
+use PHPStan\Testing\PHPStanTestCase;
+
+/**
+ * End-to-end proof for #74 using the real rules.neon collector/rule boundary.
+ */
+final class TraitContextIntegrationTest extends PHPStanTestCase
+{
+    private const TRAIT_FIXTURE = __DIR__ . '/fixtures/TraitContext/LooseComparisonTrait.php';
+    private const INT_CONSUMER_ONE_FIXTURE = __DIR__ . '/fixtures/TraitContext/IntTraitConsumerOne.php';
+    private const INT_CONSUMER_TWO_FIXTURE = __DIR__ . '/fixtures/TraitContext/IntTraitConsumerTwo.php';
+    private const STRING_CONSUMER_FIXTURE = __DIR__ . '/fixtures/TraitContext/StringTraitConsumer.php';
+    private const TRAIT_COMPARISON_LINE = 11;
+
+    /**
+     * @return array<int, string>
+     */
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [
+            \dirname(__DIR__) . '/rules.neon',
+        ];
+    }
+
+    public function testSingleIntConsumerKeepsItsTraitDiagnostics(): void
+    {
+        $errors = $this->vokuErrors($this->runAnalyse([
+            self::TRAIT_FIXTURE,
+            self::INT_CONSUMER_ONE_FIXTURE,
+        ]));
+
+        self::assertMessageCount($errors, "Condition between '' and int are falsy", 1);
+        self::assertMessageCount($errors, 'double negative integer conditions', 1);
+        self::assertTraitSourceForMatchingErrors($errors, 'double negative integer conditions');
+    }
+
+    public function testTwoEquivalentIntConsumersPublishEachTraitDiagnosticOnce(): void
+    {
+        $errors = $this->vokuErrors($this->runAnalyse([
+            self::TRAIT_FIXTURE,
+            self::INT_CONSUMER_ONE_FIXTURE,
+            self::INT_CONSUMER_TWO_FIXTURE,
+        ]));
+
+        self::assertMessageCount($errors, "Condition between '' and int are falsy", 1);
+        self::assertMessageCount($errors, 'double negative integer conditions', 1);
+        self::assertTraitSourceForMatchingErrors($errors, 'double negative integer conditions');
+    }
+
+    public function testDifferentUsingClassContextsDoNotPublishContextSpecificTraitDiagnostics(): void
+    {
+        $errors = $this->vokuErrors($this->runAnalyse([
+            self::TRAIT_FIXTURE,
+            self::INT_CONSUMER_ONE_FIXTURE,
+            self::STRING_CONSUMER_FIXTURE,
+        ]));
+
+        self::assertMessageCount($errors, "Condition between '' and int are falsy", 0);
+        self::assertMessageCount($errors, 'double negative integer conditions', 0);
+        self::assertMessageCount($errors, 'double negative string conditions', 0);
+    }
+
+    /**
+     * @param array<int, string> $files
+     *
+     * @return array<int, Error>
+     */
+    private function runAnalyse(array $files): array
+    {
+        /** @var FileHelper $fileHelper */
+        $fileHelper = self::getContainer()->getByType(FileHelper::class);
+        foreach ($files as $index => $file) {
+            $files[$index] = $fileHelper->normalizePath($file);
+        }
+
+        /** @var Analyser $analyser */
+        $analyser = self::getContainer()->getByType(Analyser::class);
+
+        return $analyser->analyse($files)->getErrors();
+    }
+
+    /**
+     * @param array<int, Error> $errors
+     *
+     * @return array<int, Error>
+     */
+    private function vokuErrors(array $errors): array
+    {
+        return \array_values(\array_filter(
+            $errors,
+            static function (Error $error): bool {
+                $identifier = $error->getIdentifier();
+
+                return $identifier !== null && \strpos($identifier, 'voku.') === 0;
+            }
+        ));
+    }
+
+    /**
+     * @param array<int, Error> $errors
+     */
+    private static function assertMessageCount(array $errors, string $needle, int $expectedCount): void
+    {
+        $count = 0;
+        foreach ($errors as $error) {
+            if (\strpos($error->getMessage(), $needle) !== false) {
+                ++$count;
+            }
+        }
+
+        static::assertSame($expectedCount, $count, 'Unexpected diagnostic count for: ' . $needle);
+    }
+
+    /**
+     * @param array<int, Error> $errors
+     */
+    private static function assertTraitSourceForMatchingErrors(array $errors, string $needle): void
+    {
+        $matched = false;
+
+        foreach ($errors as $error) {
+            if (\strpos($error->getMessage(), $needle) === false) {
+                continue;
+            }
+
+            $matched = true;
+            static::assertSame(self::TRAIT_COMPARISON_LINE, $error->getLine());
+            static::assertSame('LooseComparisonTrait.php', \basename($error->getFilePath()));
+        }
+
+        static::assertTrue($matched, 'Expected at least one trait diagnostic containing: ' . $needle);
+    }
+}


### PR DESCRIPTION
## Summary

Implement #74 without raising the declared PHPStan `~2.0` floor.

- keep ordinary `IfConditionRule` behavior unchanged outside traits;
- suppress eager trait-context publication from the direct rule;
- collect the same message-level diagnostics for every using-class context through PHPStan's public Collector API;
- publish only diagnostics that are present in every observed context for the same trait expression;
- publish common diagnostics once against the trait file rather than attributing them to an arbitrary consumer;
- preserve existing message identifiers and line numbers;
- keep empty per-context collections so a valid no-error context participates in the intersection instead of disappearing;
- add end-to-end analyzer coverage for one int consumer, two equivalent int consumers, and mixed int/string consumers;
- cover `rules.neon` collector/rule registration.

## Compatibility decision

No PHPStan minimum bump. `Collector`, `CollectedDataNode`, trait-aware `Scope`, and file-aware `RuleErrorBuilder` are already public API in PHPStan 2.0.0, so this package can own the small message-level compatibility layer instead of depending on PHPStan 2.2's specialized constant-condition helper/collector internals.

## Safety invariant

A trait diagnostic is published only when the same message/identifier/line exists in every observed using-class context for that source expression. Context-specific findings are suppressed rather than guessed or deduplicated by line.

## Validation

Draft until the exact-head PHP 7.4–8.4 matrix and PHPStan job are green.

Closes #74