### PR TITLE
Update upcoming changelog for comparison-rule changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### Upcoming
+- propagate `checkYodaConditions` to ternary, match and switch rules, and fix definite array/non-array checks in binary and assignment operators
+- add opt-in `InArrayLooseComparisonRule` for PHP 7/8 loose-comparison surprises in `in_array()` and `array_search()`
+- add `voku.reportDuplicateNativeComparisons` to suppress proven PHPStan-native comparison overlap while preserving extension-specific advice and PHPStan last-condition/PHPDoc-certainty behavior
+- defer trait-body comparison diagnostics across using-class contexts to avoid per-use duplicates and suppress context-specific false positives
+
 ### 3.7.0 (2026-04-28)
 - detect disguised constant ternary conditions and dedupe duplicate diagnostics
 - allow enum `$this` in `match` expressions without direct-object-comparison errors


### PR DESCRIPTION
## Summary

Document the user-visible changes merged after 3.7.0 without turning the changelog into a PR ledger.

- record `checkYodaConditions` propagation and the repaired definite array/non-array operator checks;
- document the opt-in `InArrayLooseComparisonRule` for PHP 7/8 loose-comparison surprises;
- document `voku.reportDuplicateNativeComparisons` and its PHPStan-aware suppression behavior;
- document context-aware trait diagnostic deferral that removes per-use duplicates and context-specific false positives;
- intentionally omit workflow-only and evidence-only changes with no production behavior impact.

This keeps the next release notes focused on consumer-visible behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an “Upcoming” changelog section outlining planned rule improvements.
  * Future updates will extend Yoda-condition checks across additional expressions and improve definite array/non-array checks.
  * Added a planned opt-in rule for detecting surprising loose comparisons in `in_array()` and `array_search()`.
  * Documented configuration to reduce duplicate native comparison reports while retaining extension-specific guidance.
  * Documented improvements to trait comparison diagnostics to reduce duplicate and context-specific findings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->