### PR TITLE
Fix comparison policy propagation and restore blocking self-analysis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
             php vendor/bin/phpunit -c phpunit.xml --coverage-clover=build/logs/clover.xml
 
       - name: Run phpstan
-        if: ${{ matrix.php == '7.4' }}
+        if: ${{ matrix.php == '8.4' }}
         run: |
           php vendor/bin/phpstan analyse
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,6 @@ jobs:
             php vendor/bin/phpunit -c phpunit.xml --coverage-clover=build/logs/clover.xml
 
       - name: Run phpstan
-        continue-on-error: true
         if: ${{ matrix.php == '7.4' }}
         run: |
           php vendor/bin/phpstan analyse

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ### Upcoming
+- restore clean self-analysis for the comparison policy, make PHPStan analysis blocking in CI, and propagate duplicate-native suppression through ternary, match, switch and boolean condition rules
 - propagate `checkYodaConditions` to ternary, match and switch rules, and fix definite array/non-array checks in binary and assignment operators
 - add opt-in `InArrayLooseComparisonRule` for PHP 7/8 loose-comparison surprises in `in_array()` and `array_search()`
 - add `voku.reportDuplicateNativeComparisons` to suppress proven PHPStan-native comparison overlap while preserving extension-specific advice and PHPStan last-condition/PHPDoc-certainty behavior
@@ -86,7 +87,7 @@
 - PHP8: check empty string checks on 0 values: https://3v4l.org/lBFHI
 
 ### 1.8.2 (2022-07-18)
-- fix for `count($a) === 0` instead of something like `if (!$a)`
+- use `count($a) === 0` instead of something like `if (!$a)`
 
 ### 1.8.1 (2022-07-18)
 - use `count($a) === 0` instead of something like `elseif (!$a)`
@@ -97,49 +98,3 @@
 ### 1.7.0 (2022-07-07)
 - use `count($a) > 0` instead of something like `if ($a)`
 - check non-empty array is never empty
-
-### 1.6.3 (2022-05-11)
-- do not compare objects with another type: fix false-positive errors
-
-### 1.6.2 (2022-05-11)
-- do not compare objects with another type: allow AND && OR conditions
-
-### 1.6.1 (2022-05-11)
-- do not compare objects with another type: allow NULL and BOOLEAN checks
-
-### 1.6.0 (2022-05-11)
-- check more conditions (left <-> right) | thanks @Slamdunk
-- check DateTime/DateTimeImmutable conditions | thanks @Slamdunk
-
-### 1.5.2 (2022-05-09)
-- do not compare objects with another type: allow UnionType with the same ObjectType and NULL
-
-### 1.5.1 (2022-05-09)
-- do not compare objects with another type: allow NULL checks
-
-### 1.5.0 (2022-05-09)
-- inspect all binary operations regardless within or without if/else statement | thanks @Slamdunk
-- do not compare objects with another type: allow $this object type comparison | thanks @Slamdunk
-- do not compare objects with another type: allow object strict comparison for ENUM types | thanks @Slamdunk
-
-### 1.4.0 (2022-04-13)
-- fix ternary checks
-- re-add the "Non-empty string is always non-empty." check
-- add tests and ci config
-
-### 1.3.0 (2022-04-11)
-- add checks for boolean <> string conditions
-- add checks for non-nullable object conditions
-- use the same checks for "left <-> right" and "right <-> left" 
-
-### 1.2.1 (2022-04-06)
-- add check for boolean <> integer conditions
-
-### 1.2.0 (2022-02-23)
-- add check for call method on NULL before level 8
-
-### 1.1.0 (2022-02-17)
-- check also for "Non-empty string is always empty."
-
-### 1.0.0 (2022-02-17)
-- Initial release with checks for "conditions"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,7 +87,7 @@
 - PHP8: check empty string checks on 0 values: https://3v4l.org/lBFHI
 
 ### 1.8.2 (2022-07-18)
-- use `count($a) === 0` instead of something like `if (!$a)`
+- fix for `count($a) === 0` instead of something like `if (!$a)`
 
 ### 1.8.1 (2022-07-18)
 - use `count($a) === 0` instead of something like `elseif (!$a)`
@@ -98,3 +98,49 @@
 ### 1.7.0 (2022-07-07)
 - use `count($a) > 0` instead of something like `if ($a)`
 - check non-empty array is never empty
+
+### 1.6.3 (2022-05-11)
+- do not compare objects with another type: fix false-positive errors
+
+### 1.6.2 (2022-05-11)
+- do not compare objects with another type: allow AND && OR conditions
+
+### 1.6.1 (2022-05-11)
+- do not compare objects with another type: allow NULL and BOOLEAN checks
+
+### 1.6.0 (2022-05-11)
+- check more conditions (left <-> right) | thanks @Slamdunk
+- check DateTime/DateTimeImmutable conditions | thanks @Slamdunk
+
+### 1.5.2 (2022-05-09)
+- do not compare objects with another type: allow UnionType with the same ObjectType and NULL
+
+### 1.5.1 (2022-05-09)
+- do not compare objects with another type: allow NULL checks
+
+### 1.5.0 (2022-05-09)
+- inspect all binary operations regardless within or without if/else statement | thanks @Slamdunk
+- do not compare objects with another type: allow $this object type comparison | thanks @Slamdunk
+- do not compare objects with another type: allow object strict comparison for ENUM types | thanks @Slamdunk
+
+### 1.4.0 (2022-04-13)
+- fix ternary checks
+- re-add the "Non-empty string is always non-empty." check
+- add tests and ci config
+
+### 1.3.0 (2022-04-11)
+- add checks for boolean <> string conditions
+- add checks for non-nullable object conditions
+- use the same checks for "left <-> right" and "right <-> left" 
+
+### 1.2.1 (2022-04-06)
+- add check for boolean <> integer conditions
+
+### 1.2.0 (2022-02-23)
+- add check for call method on NULL before level 8
+
+### 1.1.0 (2022-02-17)
+- check also for "Non-empty string is always empty."
+
+### 1.0.0 (2022-02-17)
+- Initial release with checks for "conditions"

--- a/rules.neon
+++ b/rules.neon
@@ -42,6 +42,9 @@ services:
 			classesNotInIfConditions: %voku.classesNotInIfConditions%
 			checkYodaConditions: %voku.checkYodaConditions%
 			checkForAssignments: %voku.checkForAssignments%
+			reportDuplicateNativeComparisons: %voku.reportDuplicateNativeComparisons%
+			reportAlwaysTrueInLastCondition: %reportAlwaysTrueInLastCondition%
+			treatPhpDocTypesAsCertain: %treatPhpDocTypesAsCertain%
 		tags:
 			- phpstan.rules.rule
 
@@ -51,6 +54,9 @@ services:
 			classesNotInIfConditions: %voku.classesNotInIfConditions%
 			checkYodaConditions: %voku.checkYodaConditions%
 			checkForAssignments: %voku.checkForAssignments%
+			reportDuplicateNativeComparisons: %voku.reportDuplicateNativeComparisons%
+			reportAlwaysTrueInLastCondition: %reportAlwaysTrueInLastCondition%
+			treatPhpDocTypesAsCertain: %treatPhpDocTypesAsCertain%
 		tags:
 			- phpstan.rules.rule
 
@@ -60,6 +66,9 @@ services:
 			classesNotInIfConditions: %voku.classesNotInIfConditions%
 			checkYodaConditions: %voku.checkYodaConditions%
 			checkForAssignments: %voku.checkForAssignments%
+			reportDuplicateNativeComparisons: %voku.reportDuplicateNativeComparisons%
+			reportAlwaysTrueInLastCondition: %reportAlwaysTrueInLastCondition%
+			treatPhpDocTypesAsCertain: %treatPhpDocTypesAsCertain%
 		tags:
 			- phpstan.rules.rule
 
@@ -116,6 +125,9 @@ services:
 			classesNotInIfConditions: %voku.classesNotInIfConditions%
 			checkForAssignments: %voku.checkForAssignments%
 			checkYodaConditions: %voku.checkYodaConditions%
+			reportDuplicateNativeComparisons: %voku.reportDuplicateNativeComparisons%
+			reportAlwaysTrueInLastCondition: %reportAlwaysTrueInLastCondition%
+			treatPhpDocTypesAsCertain: %treatPhpDocTypesAsCertain%
 		tags:
 			- phpstan.rules.rule
 
@@ -125,6 +137,9 @@ services:
 			classesNotInIfConditions: %voku.classesNotInIfConditions%
 			checkForAssignments: %voku.checkForAssignments%
 			checkYodaConditions: %voku.checkYodaConditions%
+			reportDuplicateNativeComparisons: %voku.reportDuplicateNativeComparisons%
+			reportAlwaysTrueInLastCondition: %reportAlwaysTrueInLastCondition%
+			treatPhpDocTypesAsCertain: %treatPhpDocTypesAsCertain%
 		tags:
 			- phpstan.rules.rule
 			
@@ -134,5 +149,8 @@ services:
 			classesNotInIfConditions: %voku.classesNotInIfConditions%
 			checkForAssignments: %voku.checkForAssignments%
 			checkYodaConditions: %voku.checkYodaConditions%
+			reportDuplicateNativeComparisons: %voku.reportDuplicateNativeComparisons%
+			reportAlwaysTrueInLastCondition: %reportAlwaysTrueInLastCondition%
+			treatPhpDocTypesAsCertain: %treatPhpDocTypesAsCertain%
 		tags:
 			- phpstan.rules.rule

--- a/src/voku/PHPStan/Rules/IfConditionBooleanAndRule.php
+++ b/src/voku/PHPStan/Rules/IfConditionBooleanAndRule.php
@@ -14,7 +14,6 @@ use PHPStan\Rules\Rule;
  */
 final class IfConditionBooleanAndRule implements Rule
 {
-
     /**
      * @var array<int, class-string>
      */
@@ -36,22 +35,39 @@ final class IfConditionBooleanAndRule implements Rule
     private $reflectionProvider;
 
     /**
+     * @var bool
+     */
+    private $reportDuplicateNativeComparisons;
+
+    /**
+     * @var bool
+     */
+    private $reportAlwaysTrueInLastCondition;
+
+    /**
+     * @var bool
+     */
+    private $treatPhpDocTypesAsCertain;
+
+    /**
      * @param array<int, class-string> $classesNotInIfConditions
      */
     public function __construct(
         array $classesNotInIfConditions,
         ?ReflectionProvider $reflectionProvider = null,
         bool $checkForAssignments = false,
-        bool $checkYodaConditions = false
-    )
-    {
+        bool $checkYodaConditions = false,
+        bool $reportDuplicateNativeComparisons = true,
+        bool $reportAlwaysTrueInLastCondition = true,
+        bool $treatPhpDocTypesAsCertain = true
+    ) {
         $this->reflectionProvider = $reflectionProvider;
-
         $this->classesNotInIfConditions = $classesNotInIfConditions;
-
         $this->checkForAssignments = $checkForAssignments;
-        
         $this->checkYodaConditions = $checkYodaConditions;
+        $this->reportDuplicateNativeComparisons = $reportDuplicateNativeComparisons;
+        $this->reportAlwaysTrueInLastCondition = $reportAlwaysTrueInLastCondition;
+        $this->treatPhpDocTypesAsCertain = $treatPhpDocTypesAsCertain;
     }
 
     public function getNodeType(): string
@@ -66,10 +82,9 @@ final class IfConditionBooleanAndRule implements Rule
      */
     public function processNode(Node $node, Scope $scope): array
     {
-        $cond = $node->getOriginalNode();
-        
+        $condition = $node->getOriginalNode();
         $errors = IfConditionHelper::processBooleanNodeHelper(
-            $cond,
+            $condition,
             $scope,
             $this->classesNotInIfConditions,
             $node,
@@ -78,6 +93,17 @@ final class IfConditionBooleanAndRule implements Rule
             $this->checkYodaConditions
         );
 
-        return $errors;
+        if (!$condition instanceof Node\Expr\BinaryOp) {
+            return $errors;
+        }
+
+        return IfConditionDiagnosticPolicy::filterBinaryComparison(
+            $condition,
+            $scope,
+            $errors,
+            $this->reportDuplicateNativeComparisons,
+            $this->reportAlwaysTrueInLastCondition,
+            $this->treatPhpDocTypesAsCertain
+        );
     }
 }

--- a/src/voku/PHPStan/Rules/IfConditionBooleanAndRule.php
+++ b/src/voku/PHPStan/Rules/IfConditionBooleanAndRule.php
@@ -93,10 +93,6 @@ final class IfConditionBooleanAndRule implements Rule
             $this->checkYodaConditions
         );
 
-        if (!$condition instanceof Node\Expr\BinaryOp) {
-            return $errors;
-        }
-
         return IfConditionDiagnosticPolicy::filterBinaryComparison(
             $condition,
             $scope,

--- a/src/voku/PHPStan/Rules/IfConditionBooleanNotRule.php
+++ b/src/voku/PHPStan/Rules/IfConditionBooleanNotRule.php
@@ -14,7 +14,6 @@ use PHPStan\Rules\Rule;
  */
 final class IfConditionBooleanNotRule implements Rule
 {
-
     /**
      * @var array<int, class-string>
      */
@@ -36,22 +35,39 @@ final class IfConditionBooleanNotRule implements Rule
     private $reflectionProvider;
 
     /**
+     * @var bool
+     */
+    private $reportDuplicateNativeComparisons;
+
+    /**
+     * @var bool
+     */
+    private $reportAlwaysTrueInLastCondition;
+
+    /**
+     * @var bool
+     */
+    private $treatPhpDocTypesAsCertain;
+
+    /**
      * @param array<int, class-string> $classesNotInIfConditions
      */
     public function __construct(
         array $classesNotInIfConditions,
         ?ReflectionProvider $reflectionProvider = null,
-        bool                $checkForAssignments = false,
-        bool                $checkYodaConditions = false
-    )
-    {
+        bool $checkForAssignments = false,
+        bool $checkYodaConditions = false,
+        bool $reportDuplicateNativeComparisons = true,
+        bool $reportAlwaysTrueInLastCondition = true,
+        bool $treatPhpDocTypesAsCertain = true
+    ) {
         $this->reflectionProvider = $reflectionProvider;
-
         $this->classesNotInIfConditions = $classesNotInIfConditions;
-
         $this->checkForAssignments = $checkForAssignments;
-        
         $this->checkYodaConditions = $checkYodaConditions;
+        $this->reportDuplicateNativeComparisons = $reportDuplicateNativeComparisons;
+        $this->reportAlwaysTrueInLastCondition = $reportAlwaysTrueInLastCondition;
+        $this->treatPhpDocTypesAsCertain = $treatPhpDocTypesAsCertain;
     }
 
     public function getNodeType(): string
@@ -66,7 +82,7 @@ final class IfConditionBooleanNotRule implements Rule
      */
     public function processNode(Node $node, Scope $scope): array
     {
-        return IfConditionHelper::processBooleanNodeHelper(
+        $errors = IfConditionHelper::processBooleanNodeHelper(
             $node->expr,
             $scope,
             $this->classesNotInIfConditions,
@@ -74,6 +90,19 @@ final class IfConditionBooleanNotRule implements Rule
             $this->reflectionProvider,
             $this->checkForAssignments,
             $this->checkYodaConditions
+        );
+
+        if (!$node->expr instanceof Node\Expr\BinaryOp) {
+            return $errors;
+        }
+
+        return IfConditionDiagnosticPolicy::filterBinaryComparison(
+            $node->expr,
+            $scope,
+            $errors,
+            $this->reportDuplicateNativeComparisons,
+            $this->reportAlwaysTrueInLastCondition,
+            $this->treatPhpDocTypesAsCertain
         );
     }
 }

--- a/src/voku/PHPStan/Rules/IfConditionBooleanOrRule.php
+++ b/src/voku/PHPStan/Rules/IfConditionBooleanOrRule.php
@@ -14,7 +14,6 @@ use PHPStan\Rules\Rule;
  */
 final class IfConditionBooleanOrRule implements Rule
 {
-
     /**
      * @var array<int, class-string>
      */
@@ -36,22 +35,39 @@ final class IfConditionBooleanOrRule implements Rule
     private $reflectionProvider;
 
     /**
+     * @var bool
+     */
+    private $reportDuplicateNativeComparisons;
+
+    /**
+     * @var bool
+     */
+    private $reportAlwaysTrueInLastCondition;
+
+    /**
+     * @var bool
+     */
+    private $treatPhpDocTypesAsCertain;
+
+    /**
      * @param array<int, class-string> $classesNotInIfConditions
      */
     public function __construct(
         array $classesNotInIfConditions,
         ?ReflectionProvider $reflectionProvider = null,
         bool $checkForAssignments = false,
-        bool $checkYodaConditions = false
-    )
-    {
+        bool $checkYodaConditions = false,
+        bool $reportDuplicateNativeComparisons = true,
+        bool $reportAlwaysTrueInLastCondition = true,
+        bool $treatPhpDocTypesAsCertain = true
+    ) {
         $this->reflectionProvider = $reflectionProvider;
-
         $this->classesNotInIfConditions = $classesNotInIfConditions;
-
         $this->checkForAssignments = $checkForAssignments;
-        
         $this->checkYodaConditions = $checkYodaConditions;
+        $this->reportDuplicateNativeComparisons = $reportDuplicateNativeComparisons;
+        $this->reportAlwaysTrueInLastCondition = $reportAlwaysTrueInLastCondition;
+        $this->treatPhpDocTypesAsCertain = $treatPhpDocTypesAsCertain;
     }
 
     public function getNodeType(): string
@@ -66,10 +82,9 @@ final class IfConditionBooleanOrRule implements Rule
      */
     public function processNode(Node $node, Scope $scope): array
     {
-        $cond = $node->getOriginalNode();
-
+        $condition = $node->getOriginalNode();
         $errors = IfConditionHelper::processBooleanNodeHelper(
-            $cond,
+            $condition,
             $scope,
             $this->classesNotInIfConditions,
             $node,
@@ -78,6 +93,17 @@ final class IfConditionBooleanOrRule implements Rule
             $this->checkYodaConditions
         );
 
-        return $errors;
+        if (!$condition instanceof Node\Expr\BinaryOp) {
+            return $errors;
+        }
+
+        return IfConditionDiagnosticPolicy::filterBinaryComparison(
+            $condition,
+            $scope,
+            $errors,
+            $this->reportDuplicateNativeComparisons,
+            $this->reportAlwaysTrueInLastCondition,
+            $this->treatPhpDocTypesAsCertain
+        );
     }
 }

--- a/src/voku/PHPStan/Rules/IfConditionBooleanOrRule.php
+++ b/src/voku/PHPStan/Rules/IfConditionBooleanOrRule.php
@@ -93,10 +93,6 @@ final class IfConditionBooleanOrRule implements Rule
             $this->checkYodaConditions
         );
 
-        if (!$condition instanceof Node\Expr\BinaryOp) {
-            return $errors;
-        }
-
         return IfConditionDiagnosticPolicy::filterBinaryComparison(
             $condition,
             $scope,

--- a/src/voku/PHPStan/Rules/IfConditionDiagnosticPolicy.php
+++ b/src/voku/PHPStan/Rules/IfConditionDiagnosticPolicy.php
@@ -6,7 +6,6 @@ namespace voku\PHPStan\Rules;
 
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;
-use PHPStan\Parser\LastConditionVisitor;
 use PHPStan\Rules\RuleError;
 use PHPStan\Type\Type;
 
@@ -19,6 +18,14 @@ use PHPStan\Type\Type;
  */
 final class IfConditionDiagnosticPolicy
 {
+    /**
+     * Mirrored from PHPStan\Parser\LastConditionVisitor::ATTRIBUTE_NAME.
+     *
+     * Referencing that class constant from src/ is outside PHPStan's backward-compatibility promise,
+     * so the value is pinned by a regression test instead.
+     */
+    private const LAST_CONDITION_ATTRIBUTE = 'isLastCondition';
+
     /**
      * @param array<int, RuleError> $errors
      *
@@ -33,12 +40,6 @@ final class IfConditionDiagnosticPolicy
         bool $treatPhpDocTypesAsCertain
     ): array
     {
-        // PHPStan defers trait constant-condition decisions across all using classes. Until VPR-4
-        // / #74 has the same contextual boundary, dropping a per-use finding here is unsafe.
-        if ($scope->isInTrait()) {
-            return $errors;
-        }
-
         $suppressNativeDuplicate = !$reportDuplicateNativeComparisons
             && self::isProvablyReportedByNativeConstantLooseComparison(
                 $condition,
@@ -103,7 +104,7 @@ final class IfConditionDiagnosticPolicy
             &&
             !$reportAlwaysTrueInLastCondition
             &&
-            $condition->getAttribute(LastConditionVisitor::ATTRIBUTE_NAME) === true
+            $condition->getAttribute(self::LAST_CONDITION_ATTRIBUTE) === true
         ) {
             // PHPStan's ConstantLooseComparisonRule deliberately returns no error here.
             return false;
@@ -122,7 +123,7 @@ final class IfConditionDiagnosticPolicy
         if (
             $reportAlwaysTrueInLastCondition
             ||
-            $condition->getAttribute(LastConditionVisitor::ATTRIBUTE_NAME) !== true
+            $condition->getAttribute(self::LAST_CONDITION_ATTRIBUTE) !== true
         ) {
             return false;
         }

--- a/src/voku/PHPStan/Rules/IfConditionMatchRule.php
+++ b/src/voku/PHPStan/Rules/IfConditionMatchRule.php
@@ -35,6 +35,21 @@ final class IfConditionMatchRule implements Rule
     private $reflectionProvider;
 
     /**
+     * @var bool
+     */
+    private $reportDuplicateNativeComparisons;
+
+    /**
+     * @var bool
+     */
+    private $reportAlwaysTrueInLastCondition;
+
+    /**
+     * @var bool
+     */
+    private $treatPhpDocTypesAsCertain;
+
+    /**
      * The first three parameters intentionally keep the legacy positional order.
      *
      * @param array<int, class-string> $classesNotInIfConditions
@@ -43,16 +58,18 @@ final class IfConditionMatchRule implements Rule
         array $classesNotInIfConditions,
         bool $checkForAssignments = false,
         ?ReflectionProvider $reflectionProvider = null,
-        bool $checkYodaConditions = false
-    )
-    {
+        bool $checkYodaConditions = false,
+        bool $reportDuplicateNativeComparisons = true,
+        bool $reportAlwaysTrueInLastCondition = true,
+        bool $treatPhpDocTypesAsCertain = true
+    ) {
         $this->reflectionProvider = $reflectionProvider;
-
         $this->checkForAssignments = $checkForAssignments;
-
         $this->classesNotInIfConditions = $classesNotInIfConditions;
-
         $this->checkYodaConditions = $checkYodaConditions;
+        $this->reportDuplicateNativeComparisons = $reportDuplicateNativeComparisons;
+        $this->reportAlwaysTrueInLastCondition = $reportAlwaysTrueInLastCondition;
+        $this->treatPhpDocTypesAsCertain = $treatPhpDocTypesAsCertain;
     }
 
     public function getNodeType(): string
@@ -75,11 +92,11 @@ final class IfConditionMatchRule implements Rule
             }
 
             foreach ($arm->conds as $case) {
-                $errors = IfConditionHelper::processNodeHelper(
+                $caseErrors = IfConditionHelper::processNodeHelper(
                     $scope->getType($node->cond),
                     $scope->getType($case),
                     $case,
-                    $errors,
+                    [],
                     $this->classesNotInIfConditions,
                     $node,
                     $this->reflectionProvider,
@@ -87,8 +104,8 @@ final class IfConditionMatchRule implements Rule
                     $this->checkYodaConditions
                 );
 
-                $errors = array_merge(
-                    $errors,
+                $caseErrors = array_merge(
+                    $caseErrors,
                     IfConditionHelper::processNestedObjectComparisons(
                         $case,
                         $scope,
@@ -97,9 +114,22 @@ final class IfConditionMatchRule implements Rule
                         $this->reflectionProvider
                     )
                 );
+
+                if ($case instanceof Node\Expr\BinaryOp) {
+                    $caseErrors = IfConditionDiagnosticPolicy::filterBinaryComparison(
+                        $case,
+                        $scope,
+                        $caseErrors,
+                        $this->reportDuplicateNativeComparisons,
+                        $this->reportAlwaysTrueInLastCondition,
+                        $this->treatPhpDocTypesAsCertain
+                    );
+                }
+
+                $errors = array_merge($errors, $caseErrors);
             }
         }
 
-        return $errors;
+        return IfConditionHelper::deduplicateErrors($errors);
     }
 }

--- a/src/voku/PHPStan/Rules/IfConditionSwitchCaseRule.php
+++ b/src/voku/PHPStan/Rules/IfConditionSwitchCaseRule.php
@@ -35,6 +35,21 @@ final class IfConditionSwitchCaseRule implements Rule
     private $reflectionProvider;
 
     /**
+     * @var bool
+     */
+    private $reportDuplicateNativeComparisons;
+
+    /**
+     * @var bool
+     */
+    private $reportAlwaysTrueInLastCondition;
+
+    /**
+     * @var bool
+     */
+    private $treatPhpDocTypesAsCertain;
+
+    /**
      * The first three parameters intentionally keep the legacy positional order.
      *
      * @param array<int, class-string> $classesNotInIfConditions
@@ -43,16 +58,18 @@ final class IfConditionSwitchCaseRule implements Rule
         array $classesNotInIfConditions,
         bool $checkForAssignments = false,
         ?ReflectionProvider $reflectionProvider = null,
-        bool $checkYodaConditions = false
-    )
-    {
+        bool $checkYodaConditions = false,
+        bool $reportDuplicateNativeComparisons = true,
+        bool $reportAlwaysTrueInLastCondition = true,
+        bool $treatPhpDocTypesAsCertain = true
+    ) {
         $this->reflectionProvider = $reflectionProvider;
-
         $this->checkForAssignments = $checkForAssignments;
-
         $this->classesNotInIfConditions = $classesNotInIfConditions;
-
         $this->checkYodaConditions = $checkYodaConditions;
+        $this->reportDuplicateNativeComparisons = $reportDuplicateNativeComparisons;
+        $this->reportAlwaysTrueInLastCondition = $reportAlwaysTrueInLastCondition;
+        $this->treatPhpDocTypesAsCertain = $treatPhpDocTypesAsCertain;
     }
 
     public function getNodeType(): string
@@ -70,11 +87,12 @@ final class IfConditionSwitchCaseRule implements Rule
         $errors = [];
 
         foreach ($node->cases as $case) {
-            $errors = IfConditionHelper::processNodeHelper(
+            $condition = $case->cond === null ? $node->cond : $case->cond;
+            $caseErrors = IfConditionHelper::processNodeHelper(
                 $scope->getType($node->cond),
                 $case->cond === null ? null : $scope->getType($case->cond),
-                $case->cond === null ? $node->cond : $case->cond,
-                $errors,
+                $condition,
+                [],
                 $this->classesNotInIfConditions,
                 $node,
                 $this->reflectionProvider,
@@ -83,8 +101,8 @@ final class IfConditionSwitchCaseRule implements Rule
             );
 
             if ($case->cond !== null) {
-                $errors = array_merge(
-                    $errors,
+                $caseErrors = array_merge(
+                    $caseErrors,
                     IfConditionHelper::processNestedObjectComparisons(
                         $case->cond,
                         $scope,
@@ -93,9 +111,22 @@ final class IfConditionSwitchCaseRule implements Rule
                         $this->reflectionProvider
                     )
                 );
+
+                if ($case->cond instanceof Node\Expr\BinaryOp) {
+                    $caseErrors = IfConditionDiagnosticPolicy::filterBinaryComparison(
+                        $case->cond,
+                        $scope,
+                        $caseErrors,
+                        $this->reportDuplicateNativeComparisons,
+                        $this->reportAlwaysTrueInLastCondition,
+                        $this->treatPhpDocTypesAsCertain
+                    );
+                }
             }
+
+            $errors = array_merge($errors, $caseErrors);
         }
 
-        return $errors;
+        return IfConditionHelper::deduplicateErrors($errors);
     }
 }

--- a/src/voku/PHPStan/Rules/IfConditionTernaryOperatorRule.php
+++ b/src/voku/PHPStan/Rules/IfConditionTernaryOperatorRule.php
@@ -35,22 +35,39 @@ final class IfConditionTernaryOperatorRule implements Rule
     private $reflectionProvider;
 
     /**
+     * @var bool
+     */
+    private $reportDuplicateNativeComparisons;
+
+    /**
+     * @var bool
+     */
+    private $reportAlwaysTrueInLastCondition;
+
+    /**
+     * @var bool
+     */
+    private $treatPhpDocTypesAsCertain;
+
+    /**
      * @param array<int, class-string> $classesNotInIfConditions
      */
     public function __construct(
         array $classesNotInIfConditions,
         ?ReflectionProvider $reflectionProvider = null,
-        bool                $checkForAssignments = false,
-        bool                $checkYodaConditions = false
-    )
-    {
+        bool $checkForAssignments = false,
+        bool $checkYodaConditions = false,
+        bool $reportDuplicateNativeComparisons = true,
+        bool $reportAlwaysTrueInLastCondition = true,
+        bool $treatPhpDocTypesAsCertain = true
+    ) {
         $this->reflectionProvider = $reflectionProvider;
-
         $this->classesNotInIfConditions = $classesNotInIfConditions;
-
         $this->checkForAssignments = $checkForAssignments;
-
         $this->checkYodaConditions = $checkYodaConditions;
+        $this->reportDuplicateNativeComparisons = $reportDuplicateNativeComparisons;
+        $this->reportAlwaysTrueInLastCondition = $reportAlwaysTrueInLastCondition;
+        $this->treatPhpDocTypesAsCertain = $treatPhpDocTypesAsCertain;
     }
 
     public function getNodeType(): string
@@ -84,7 +101,7 @@ final class IfConditionTernaryOperatorRule implements Rule
             );
         }
 
-        return IfConditionHelper::processBooleanNodeHelper(
+        $errors = IfConditionHelper::processBooleanNodeHelper(
             $node->cond,
             $scope,
             $this->classesNotInIfConditions,
@@ -92,6 +109,19 @@ final class IfConditionTernaryOperatorRule implements Rule
             $this->reflectionProvider,
             $this->checkForAssignments,
             $this->checkYodaConditions
+        );
+
+        if (!$node->cond instanceof Node\Expr\BinaryOp) {
+            return $errors;
+        }
+
+        return IfConditionDiagnosticPolicy::filterBinaryComparison(
+            $node->cond,
+            $scope,
+            $errors,
+            $this->reportDuplicateNativeComparisons,
+            $this->reportAlwaysTrueInLastCondition,
+            $this->treatPhpDocTypesAsCertain
         );
     }
 

--- a/src/voku/PHPStan/Rules/TraitContextComparisonCollector.php
+++ b/src/voku/PHPStan/Rules/TraitContextComparisonCollector.php
@@ -76,10 +76,6 @@ final class TraitContextComparisonCollector implements Collector
         }
 
         $traitReflection = $scope->getTraitReflection();
-        if ($traitReflection === null) {
-            return null;
-        }
-
         $traitFile = $traitReflection->getFileName();
         if ($traitFile === null) {
             return null;

--- a/tests/ComparisonDiagnosticPolicyPropagationTest.php
+++ b/tests/ComparisonDiagnosticPolicyPropagationTest.php
@@ -36,6 +36,9 @@ final class ComparisonDiagnosticPolicyPropagationTest extends RuleTestCase
         return $this->ruleUnderTest;
     }
 
+    /**
+     * @requires PHP >= 8.0
+     */
     public function testTernaryRuleUsesDuplicateNativePolicy(): void
     {
         $this->ruleUnderTest = new IfConditionTernaryOperatorRule(
@@ -51,6 +54,9 @@ final class ComparisonDiagnosticPolicyPropagationTest extends RuleTestCase
         $this->assertGenericNativeOverlapIsSuppressed([self::FIXTURE]);
     }
 
+    /**
+     * @requires PHP >= 8.0
+     */
     public function testSwitchRuleUsesDuplicateNativePolicy(): void
     {
         $this->ruleUnderTest = new IfConditionSwitchCaseRule(
@@ -66,6 +72,9 @@ final class ComparisonDiagnosticPolicyPropagationTest extends RuleTestCase
         $this->assertGenericNativeOverlapIsSuppressed([self::FIXTURE]);
     }
 
+    /**
+     * @requires PHP >= 8.0
+     */
     public function testBooleanNotRuleUsesDuplicateNativePolicy(): void
     {
         $this->ruleUnderTest = new IfConditionBooleanNotRule(

--- a/tests/ComparisonDiagnosticPolicyPropagationTest.php
+++ b/tests/ComparisonDiagnosticPolicyPropagationTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace voku\PHPStan\Rules\Test;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use voku\PHPStan\Rules\IfConditionBooleanNotRule;
+use voku\PHPStan\Rules\IfConditionMatchRule;
+use voku\PHPStan\Rules\IfConditionSwitchCaseRule;
+use voku\PHPStan\Rules\IfConditionTernaryOperatorRule;
+
+/**
+ * Regression coverage for #79: the duplicate-native policy belongs to every rule that republishes
+ * diagnostics for the same loose-comparison node, not only IfConditionRule.
+ *
+ * @extends RuleTestCase<Rule>
+ */
+final class ComparisonDiagnosticPolicyPropagationTest extends RuleTestCase
+{
+    private const FIXTURE = __DIR__ . '/fixtures/DuplicateNativeComparisonPropagationFixtures.php';
+    private const MATCH_FIXTURE = __DIR__ . '/fixtures/DuplicateNativeComparisonPropagationMatchFixtures.php';
+
+    /**
+     * @var Rule|null
+     */
+    private $ruleUnderTest;
+
+    protected function getRule(): Rule
+    {
+        if ($this->ruleUnderTest === null) {
+            throw new \LogicException('The rule under test has to be selected by the test method.');
+        }
+
+        return $this->ruleUnderTest;
+    }
+
+    public function testTernaryRuleUsesDuplicateNativePolicy(): void
+    {
+        $this->ruleUnderTest = new IfConditionTernaryOperatorRule(
+            [],
+            $this->createReflectionProvider(),
+            false,
+            false,
+            false,
+            true,
+            true
+        );
+
+        $this->assertGenericNativeOverlapIsSuppressed([self::FIXTURE]);
+    }
+
+    public function testSwitchRuleUsesDuplicateNativePolicy(): void
+    {
+        $this->ruleUnderTest = new IfConditionSwitchCaseRule(
+            [],
+            false,
+            $this->createReflectionProvider(),
+            false,
+            false,
+            true,
+            true
+        );
+
+        $this->assertGenericNativeOverlapIsSuppressed([self::FIXTURE]);
+    }
+
+    public function testBooleanNotRuleUsesDuplicateNativePolicy(): void
+    {
+        $this->ruleUnderTest = new IfConditionBooleanNotRule(
+            [],
+            $this->createReflectionProvider(),
+            false,
+            false,
+            false,
+            true,
+            true
+        );
+
+        $this->assertGenericNativeOverlapIsSuppressed([self::FIXTURE]);
+    }
+
+    /**
+     * @requires PHP >= 8.0
+     */
+    public function testMatchRuleUsesDuplicateNativePolicy(): void
+    {
+        $this->ruleUnderTest = new IfConditionMatchRule(
+            [],
+            false,
+            $this->createReflectionProvider(),
+            false,
+            false,
+            true,
+            true
+        );
+
+        $this->assertGenericNativeOverlapIsSuppressed([self::MATCH_FIXTURE]);
+    }
+
+    /**
+     * @param array<int, string> $files
+     */
+    private function assertGenericNativeOverlapIsSuppressed(array $files): void
+    {
+        $messages = [];
+        foreach ($this->gatherAnalyserErrors($files) as $error) {
+            $messages[] = $error->getMessage();
+        }
+
+        static::assertNotSame([], $messages, 'The extension-specific diagnostics must remain visible.');
+
+        foreach ($messages as $message) {
+            static::assertStringNotContainsString('Condition between ', $message);
+        }
+    }
+}

--- a/tests/IfConditionDiagnosticPolicyApiBoundaryTest.php
+++ b/tests/IfConditionDiagnosticPolicyApiBoundaryTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace voku\PHPStan\Rules\Test;
+
+use PHPStan\Parser\LastConditionVisitor;
+use PHPUnit\Framework\TestCase;
+use voku\PHPStan\Rules\IfConditionDiagnosticPolicy;
+
+final class IfConditionDiagnosticPolicyApiBoundaryTest extends TestCase
+{
+    public function testMirroredLastConditionAttributeStaysPinnedToPhpStan(): void
+    {
+        $reflection = new \ReflectionClass(IfConditionDiagnosticPolicy::class);
+        $constant = $reflection->getReflectionConstant('LAST_CONDITION_ATTRIBUTE');
+
+        static::assertNotFalse($constant);
+        static::assertSame(LastConditionVisitor::ATTRIBUTE_NAME, $constant->getValue());
+    }
+}

--- a/tests/Vpr8YodaConfigurationTest.php
+++ b/tests/Vpr8YodaConfigurationTest.php
@@ -101,7 +101,7 @@ final class Vpr8YodaConfigurationTest extends RuleTestCase
 
             static::assertSame(
                 ['classesNotInIfConditions', 'checkForAssignments', 'reflectionProvider', 'checkYodaConditions'],
-                $names
+                \array_slice($names, 0, 4)
             );
         }
     }

--- a/tests/fixtures/DuplicateNativeComparisonPropagationFixtures.php
+++ b/tests/fixtures/DuplicateNativeComparisonPropagationFixtures.php
@@ -25,15 +25,4 @@ final class DuplicateNativeComparisonPropagationFixtures
     {
         return !($value == '');
     }
-
-    /**
-     * @return string
-     */
-    public function matchCase(int $value): string
-    {
-        return match (true) {
-            $value == '' => 'a',
-            default => 'b',
-        };
-    }
 }

--- a/tests/fixtures/DuplicateNativeComparisonPropagationFixtures.php
+++ b/tests/fixtures/DuplicateNativeComparisonPropagationFixtures.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace voku\PHPStan\Rules\Test\fixtures;
+
+final class DuplicateNativeComparisonPropagationFixtures
+{
+    public function ternary(int $value): string
+    {
+        return $value == '' ? 'a' : 'b';
+    }
+
+    public function switchCase(int $value): string
+    {
+        switch (true) {
+            case $value == '':
+                return 'a';
+            default:
+                return 'b';
+        }
+    }
+
+    public function booleanNot(int $value): bool
+    {
+        return !($value == '');
+    }
+
+    /**
+     * @return string
+     */
+    public function matchCase(int $value): string
+    {
+        return match (true) {
+            $value == '' => 'a',
+            default => 'b',
+        };
+    }
+}

--- a/tests/fixtures/DuplicateNativeComparisonPropagationMatchFixtures.php
+++ b/tests/fixtures/DuplicateNativeComparisonPropagationMatchFixtures.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace voku\PHPStan\Rules\Test\fixtures;
+
+final class DuplicateNativeComparisonPropagationMatchFixtures
+{
+    public function matchCase(int $value): string
+    {
+        return match (true) {
+            $value == '' => 'a',
+            default => 'b',
+        };
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the first two regressions documented in #79 and closes the CI hole that allowed the self-analysis regression to merge.

- mirror PHPStan's last-condition attribute locally instead of referencing an API-excluded class constant from `src/`, with a PHPUnit pin against the upstream value;
- remove the unreachable trait-reflection null guard flagged by this package's own rules;
- apply `voku.reportDuplicateNativeComparisons`, `reportAlwaysTrueInLastCondition`, and `treatPhpDocTypesAsCertain` consistently to ternary, match, switch, boolean-not, boolean-and, and boolean-or rule paths;
- keep legacy constructor positions intact by appending the policy parameters;
- let the already-implemented trait collector apply the same duplicate policy instead of retaining the pre-#74 fail-open shortcut;
- add regression fixtures for the duplicate-native overlap paths;
- make `php vendor/bin/phpstan analyse` blocking on the PHP 8.4 CI lane (the analysed special fixtures use PHP 8 syntax, so the previous PHP 7.4-only analysis lane could not be made blocking without mixing in an unrelated fixture-compatibility problem);
- update the Upcoming changelog.

## Scope

This intentionally does **not** fold the `ExtendedBinaryOpRule` / `ExtendedAssignOpRule` trait-context gap into the same patch. That is a collector-boundary problem, not line-level duplicate suppression, and will be handled as the next #79 slice.

The pre-existing declared `phpstan/phpstan: ~2.0` range mismatch is also left unchanged here.

Fixes part of #79.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable reporting for duplicate native comparisons, always-true final conditions, and PHPDoc type certainty across boolean, ternary, `match`, and `switch` analyses.
  * Duplicate diagnostics are now consistently suppressed or reported across supported condition types.
  * Comparison analysis now applies consistently within traits.

* **Documentation**
  * Added upcoming changelog entries describing restored comparison analysis and diagnostic handling improvements.

* **Bug Fixes**
  * PHPStan failures now correctly fail CI validation on PHP 8.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->