### PR TITLE
Complete trait deferral for ExtendedBinaryOpRule

### DIFF
--- a/src/voku/PHPStan/Rules/ExtendedBinaryOpRule.php
+++ b/src/voku/PHPStan/Rules/ExtendedBinaryOpRule.php
@@ -14,14 +14,9 @@ use PHPStan\Rules\Rule;
 class ExtendedBinaryOpRule implements Rule
 {
     /**
-     * @var ExtendedBinaryOpRuleDiagnostics
+     * @var ExtendedBinaryOpRuleDiagnostics|null
      */
     private $diagnostics;
-
-    public function __construct()
-    {
-        $this->diagnostics = new ExtendedBinaryOpRuleDiagnostics();
-    }
 
     public function getNodeType(): string
     {
@@ -39,6 +34,15 @@ class ExtendedBinaryOpRule implements Rule
             return [];
         }
 
-        return $this->diagnostics->processNode($node, $scope);
+        return $this->getDiagnostics()->processNode($node, $scope);
+    }
+
+    private function getDiagnostics(): ExtendedBinaryOpRuleDiagnostics
+    {
+        if ($this->diagnostics === null) {
+            $this->diagnostics = new ExtendedBinaryOpRuleDiagnostics();
+        }
+
+        return $this->diagnostics;
     }
 }

--- a/src/voku/PHPStan/Rules/ExtendedBinaryOpRule.php
+++ b/src/voku/PHPStan/Rules/ExtendedBinaryOpRule.php
@@ -7,16 +7,22 @@ namespace voku\PHPStan\Rules;
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
-use PHPStan\Rules\RuleErrorBuilder;
-use PHPStan\Type\ErrorType;
-use PHPStan\Type\VerbosityLevel;
-use function sprintf;
 
 /**
  * @implements Rule<Node\Expr>
  */
 class ExtendedBinaryOpRule implements Rule
 {
+    /**
+     * @var ExtendedBinaryOpRuleDiagnostics
+     */
+    private $diagnostics;
+
+    public function __construct()
+    {
+        $this->diagnostics = new ExtendedBinaryOpRuleDiagnostics();
+    }
+
     public function getNodeType(): string
     {
         return Node\Expr\BinaryOp::class;
@@ -29,104 +35,10 @@ class ExtendedBinaryOpRule implements Rule
      */
     public function processNode(Node $node, Scope $scope): array
     {
-        $errors = [];
-
-        $leftType = $scope->getType($node->left);
-        $rightType = $scope->getType($node->right);
-
-        $errorsFound = false;
-        $this->checkErrors($node, $leftType, $rightType, $errors, $errorsFound);
-        if ($errorsFound === false) {
-            $this->checkErrors($node, $rightType, $leftType, $errors, $errorsFound);
+        if ($scope->isInTrait()) {
+            return [];
         }
 
-        return $errors;
-    }
-
-    /**
-     * @param Node\Expr\BinaryOp $node
-     * @param array<int, \PHPStan\Rules\RuleError> $errors
-     */
-    private function checkErrors(
-        Node\Expr          $node,
-        \PHPStan\Type\Type $type_1,
-        \PHPStan\Type\Type $type_2,
-        array              &$errors,
-        bool               &$errorsFound
-    ): void
-    {
-        if (
-            $node instanceof \PhpParser\Node\Expr\BinaryOp\Identical
-            ||
-            $node instanceof \PhpParser\Node\Expr\BinaryOp\NotIdentical
-            ||
-            $node instanceof \PhpParser\Node\Expr\BinaryOp\Coalesce
-            ||
-            $node instanceof \PhpParser\Node\Expr\BinaryOp\BooleanAnd
-            ||
-            $node instanceof \PhpParser\Node\Expr\BinaryOp\BooleanOr
-        ) {
-            return;
-        }
-
-        if (
-            $type_1->isString()->yes()
-            &&
-            !($type_2 instanceof \PHPStan\Type\MixedType)
-            &&
-            !IfConditionHelper::isPhpStanTypeMaybeWithUnionNullable($type_2, \PHPStan\Type\StringType::class)
-            &&
-            $type_2->describe(VerbosityLevel::typeOnly()) !== 'string' // INFO: hack for non-empty-string
-        ) {
-            if (
-                (
-                    $node instanceof Node\Expr\BinaryOp\Concat
-                    ||
-                    $node instanceof Node\Expr\BinaryOp\Equal
-                    ||
-                    $node instanceof Node\Expr\BinaryOp\NotEqual
-                )
-                &&
-                !IfConditionHelper::hasConstantStringValue($type_1, '')
-                &&
-                !($type_2->toString() instanceof ErrorType)
-            ) {
-                return;
-            }
-
-            $errors[] = IfConditionHelper::buildErrorMessage(
-                $node,
-                sprintf(
-                    'string (%s) in combination with non-string (%s) is not allowed.',
-                    $type_1->describe(VerbosityLevel::value()),
-                    $type_2->describe(VerbosityLevel::value())
-                ),
-                $node->getStartLine()
-            );
-
-            $errorsFound = true;
-
-            return;
-        }
-
-        if (
-            $type_1->isArray()->yes()
-            &&
-            !($type_2 instanceof \PHPStan\Type\MixedType)
-            &&
-            $type_2->isArray()->no()
-        ) {
-            $errors[] = IfConditionHelper::buildErrorMessage(
-                $node,
-                sprintf(
-                    'array (%s) in combination with non-array (%s) is not allowed.',
-                    $type_1->describe(VerbosityLevel::value()),
-                    $type_2->describe(VerbosityLevel::value())
-                ),
-                $node->getStartLine()
-            );
-
-            $errorsFound = true;
-        }
+        return $this->diagnostics->processNode($node, $scope);
     }
 }

--- a/src/voku/PHPStan/Rules/ExtendedBinaryOpRuleDiagnostics.php
+++ b/src/voku/PHPStan/Rules/ExtendedBinaryOpRuleDiagnostics.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace voku\PHPStan\Rules;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\RuleError;
+use PHPStan\Type\ErrorType;
+use PHPStan\Type\Type;
+use PHPStan\Type\VerbosityLevel;
+use function sprintf;
+
+/**
+ * Shared diagnostic calculation for direct and trait-context ExtendedBinaryOpRule analysis.
+ */
+final class ExtendedBinaryOpRuleDiagnostics
+{
+    /**
+     * @return array<int, RuleError>
+     */
+    public function processNode(Node\Expr\BinaryOp $node, Scope $scope): array
+    {
+        $errors = [];
+
+        $leftType = $scope->getType($node->left);
+        $rightType = $scope->getType($node->right);
+
+        $errorsFound = false;
+        $this->checkErrors($node, $leftType, $rightType, $errors, $errorsFound);
+        if ($errorsFound === false) {
+            $this->checkErrors($node, $rightType, $leftType, $errors, $errorsFound);
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @param array<int, RuleError> $errors
+     */
+    private function checkErrors(
+        Node\Expr\BinaryOp $node,
+        Type $type_1,
+        Type $type_2,
+        array &$errors,
+        bool &$errorsFound
+    ): void {
+        if (
+            $node instanceof Node\Expr\BinaryOp\Identical
+            ||
+            $node instanceof Node\Expr\BinaryOp\NotIdentical
+            ||
+            $node instanceof Node\Expr\BinaryOp\Coalesce
+            ||
+            $node instanceof Node\Expr\BinaryOp\BooleanAnd
+            ||
+            $node instanceof Node\Expr\BinaryOp\BooleanOr
+        ) {
+            return;
+        }
+
+        if (
+            $type_1->isString()->yes()
+            &&
+            !($type_2 instanceof \PHPStan\Type\MixedType)
+            &&
+            !IfConditionHelper::isPhpStanTypeMaybeWithUnionNullable($type_2, \PHPStan\Type\StringType::class)
+            &&
+            $type_2->describe(VerbosityLevel::typeOnly()) !== 'string' // INFO: hack for non-empty-string
+        ) {
+            if (
+                (
+                    $node instanceof Node\Expr\BinaryOp\Concat
+                    ||
+                    $node instanceof Node\Expr\BinaryOp\Equal
+                    ||
+                    $node instanceof Node\Expr\BinaryOp\NotEqual
+                )
+                &&
+                !IfConditionHelper::hasConstantStringValue($type_1, '')
+                &&
+                !($type_2->toString() instanceof ErrorType)
+            ) {
+                return;
+            }
+
+            $errors[] = IfConditionHelper::buildErrorMessage(
+                $node,
+                sprintf(
+                    'string (%s) in combination with non-string (%s) is not allowed.',
+                    $type_1->describe(VerbosityLevel::value()),
+                    $type_2->describe(VerbosityLevel::value())
+                ),
+                $node->getStartLine()
+            );
+
+            $errorsFound = true;
+
+            return;
+        }
+
+        if (
+            $type_1->isArray()->yes()
+            &&
+            !($type_2 instanceof \PHPStan\Type\MixedType)
+            &&
+            $type_2->isArray()->no()
+        ) {
+            $errors[] = IfConditionHelper::buildErrorMessage(
+                $node,
+                sprintf(
+                    'array (%s) in combination with non-array (%s) is not allowed.',
+                    $type_1->describe(VerbosityLevel::value()),
+                    $type_2->describe(VerbosityLevel::value())
+                ),
+                $node->getStartLine()
+            );
+
+            $errorsFound = true;
+        }
+    }
+}

--- a/src/voku/PHPStan/Rules/TraitContextComparisonCollector.php
+++ b/src/voku/PHPStan/Rules/TraitContextComparisonCollector.php
@@ -13,7 +13,7 @@ use PHPStan\Rules\IdentifierRuleError;
 use PHPStan\Rules\LineRuleError;
 
 /**
- * Collects IfConditionRule diagnostics for every using-class context of a trait expression.
+ * Collects binary comparison diagnostics for every using-class context of a trait expression.
  *
  * @implements Collector<BinaryOp, array{
  *     string,
@@ -28,7 +28,12 @@ final class TraitContextComparisonCollector implements Collector
     /**
      * @var IfConditionRuleDiagnostics
      */
-    private $diagnostics;
+    private $ifConditionDiagnostics;
+
+    /**
+     * @var ExtendedBinaryOpRuleDiagnostics
+     */
+    private $extendedBinaryOpDiagnostics;
 
     /**
      * @param array<int, class-string> $classesNotInIfConditions
@@ -42,7 +47,7 @@ final class TraitContextComparisonCollector implements Collector
         bool $reportAlwaysTrueInLastCondition = true,
         bool $treatPhpDocTypesAsCertain = true
     ) {
-        $this->diagnostics = new IfConditionRuleDiagnostics(
+        $this->ifConditionDiagnostics = new IfConditionRuleDiagnostics(
             $classesNotInIfConditions,
             $reflectionProvider,
             $checkForAssignments,
@@ -51,6 +56,7 @@ final class TraitContextComparisonCollector implements Collector
             $reportAlwaysTrueInLastCondition,
             $treatPhpDocTypesAsCertain
         );
+        $this->extendedBinaryOpDiagnostics = new ExtendedBinaryOpRuleDiagnostics();
     }
 
     public function getNodeType(): string
@@ -86,8 +92,13 @@ final class TraitContextComparisonCollector implements Collector
             ? $classReflection->getName()
             : $scope->getFileDescription();
 
+        $errors = \array_merge(
+            $this->ifConditionDiagnostics->processNode($node, $scope),
+            $this->extendedBinaryOpDiagnostics->processNode($node, $scope)
+        );
+
         $serializedErrors = [];
-        foreach ($this->diagnostics->processNode($node, $scope) as $error) {
+        foreach ($errors as $error) {
             $serializedErrors[] = [
                 $error->getMessage(),
                 $error instanceof IdentifierRuleError ? $error->getIdentifier() : null,

--- a/tests/TraitContextIntegrationTest.php
+++ b/tests/TraitContextIntegrationTest.php
@@ -20,6 +20,7 @@ final class TraitContextIntegrationTest extends PHPStanTestCase
     private const INT_CONSUMER_TWO_FIXTURE = __DIR__ . '/fixtures/TraitContext/IntTraitConsumerTwo.php';
     private const STRING_CONSUMER_FIXTURE = __DIR__ . '/fixtures/TraitContext/StringTraitConsumer.php';
     private const TRAIT_COMPARISON_LINE = 11;
+    private const EXTENDED_BINARY_MESSAGE = "string ('') in combination with non-string (int) is not allowed.";
 
     /**
      * @return array<int, string>
@@ -40,7 +41,9 @@ final class TraitContextIntegrationTest extends PHPStanTestCase
 
         self::assertMessageCount($errors, "Condition between '' and int are falsy", 1);
         self::assertMessageCount($errors, 'double negative integer conditions', 1);
+        self::assertMessageCount($errors, self::EXTENDED_BINARY_MESSAGE, 1);
         self::assertTraitSourceForMatchingErrors($errors, 'double negative integer conditions');
+        self::assertTraitSourceForMatchingErrors($errors, self::EXTENDED_BINARY_MESSAGE);
     }
 
     public function testTwoEquivalentIntConsumersPublishEachTraitDiagnosticOnce(): void
@@ -53,7 +56,9 @@ final class TraitContextIntegrationTest extends PHPStanTestCase
 
         self::assertMessageCount($errors, "Condition between '' and int are falsy", 1);
         self::assertMessageCount($errors, 'double negative integer conditions', 1);
+        self::assertMessageCount($errors, self::EXTENDED_BINARY_MESSAGE, 1);
         self::assertTraitSourceForMatchingErrors($errors, 'double negative integer conditions');
+        self::assertTraitSourceForMatchingErrors($errors, self::EXTENDED_BINARY_MESSAGE);
     }
 
     public function testDifferentUsingClassContextsDoNotPublishContextSpecificTraitDiagnostics(): void
@@ -67,6 +72,7 @@ final class TraitContextIntegrationTest extends PHPStanTestCase
         self::assertMessageCount($errors, "Condition between '' and int are falsy", 0);
         self::assertMessageCount($errors, 'double negative integer conditions', 0);
         self::assertMessageCount($errors, 'double negative string conditions', 0);
+        self::assertMessageCount($errors, self::EXTENDED_BINARY_MESSAGE, 0);
     }
 
     /**


### PR DESCRIPTION
## Summary

Completes the reproduced trait-context gap from #79 for `ExtendedBinaryOpRule`.

- extract `ExtendedBinaryOpRule`'s existing diagnostics without changing their behavior;
- keep direct non-trait analysis unchanged;
- suppress direct `ExtendedBinaryOpRule` publication while PHPStan is analysing a trait body;
- run the extracted diagnostics inside the existing `TraitContextComparisonCollector`, so identical using-class contexts are intersected and published once at the trait source;
- extend the existing end-to-end `rules.neon` trait integration test with the exact reproduced `NotEqual: string ('') in combination with non-string (int)` finding;
- prove one consumer => one finding, two equivalent consumers => still one finding, and differing int/string consumers => no context-specific finding.

The rule remains non-final and its public construction contract is unchanged; the extracted diagnostics object is initialized lazily.

## Scope

This fixes the exact `ExtendedBinaryOpRule` reproduction in #79. It does not speculate about `ExtendedAssignOpRule` without a dedicated reproduction, and it does not change the separate pre-existing PHPStan version-range decision.

Fixes the reproduced trait-binary part of #79.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection and reporting of invalid string and array comparisons.
  - Extended binary-comparison diagnostics now work consistently in trait contexts.
  - Prevented duplicate or context-specific diagnostic messages when traits are reused.
  - Preserved expected behavior for comparison operators that are intentionally excluded from these checks.

- **Tests**
  - Expanded integration coverage for trait-based comparison diagnostics, including single, repeated, and differing usage contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->