### PR TITLE
Complete trait deferral for ExtendedAssignOpRule

### DIFF
--- a/rules.neon
+++ b/rules.neon
@@ -97,6 +97,14 @@ services:
 			- phpstan.collector
 
 	-
+		class: voku\PHPStan\Rules\TraitContextAssignOpCollector
+		arguments:
+			checkYodaConditions: %voku.checkYodaConditions%
+			checkForAssignments: %voku.checkForAssignments%
+		tags:
+			- phpstan.collector
+
+	-
 		class: voku\PHPStan\Rules\TraitContextComparisonRule
 		tags:
 			- phpstan.rules.rule

--- a/src/voku/PHPStan/Rules/ExtendedAssignOpRule.php
+++ b/src/voku/PHPStan/Rules/ExtendedAssignOpRule.php
@@ -8,10 +8,6 @@ use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Rules\Rule;
-use PHPStan\Rules\RuleErrorBuilder;
-use PHPStan\Type\ErrorType;
-use PHPStan\Type\VerbosityLevel;
-use function sprintf;
 
 /**
  * @implements Rule<Node\Expr>
@@ -19,31 +15,20 @@ use function sprintf;
 class ExtendedAssignOpRule implements Rule
 {
     /**
-     * @var bool
+     * @var ExtendedAssignOpRuleDiagnostics
      */
-    private $checkForAssignments;
-
-    /**
-     * @var bool
-     */
-    private $checkYodaConditions;
-
-    /**
-     * @var ReflectionProvider
-     */
-    private $reflectionProvider;
+    private $diagnostics;
 
     public function __construct(
         ReflectionProvider $reflectionProvider,
         bool $checkForAssignments = false,
         bool $checkYodaConditions = false
-    )
-    {
-        $this->reflectionProvider = $reflectionProvider;
-
-        $this->checkForAssignments = $checkForAssignments;
-
-        $this->checkYodaConditions = $checkYodaConditions;
+    ) {
+        $this->diagnostics = new ExtendedAssignOpRuleDiagnostics(
+            $reflectionProvider,
+            $checkForAssignments,
+            $checkYodaConditions
+        );
     }
 
     public function getNodeType(): string
@@ -58,107 +43,10 @@ class ExtendedAssignOpRule implements Rule
      */
     public function processNode(Node $node, Scope $scope): array
     {
-        $errors = [];
-
-        $leftType = $scope->getType($node->var);
-        $rightType = $scope->getType($node->expr);
-
-        $errors = IfConditionHelper::processNodeHelper(
-            $leftType,
-            $rightType,
-            $node,
-            $errors,
-            [],
-            $node,
-            $this->reflectionProvider,
-            $this->checkForAssignments,
-            $this->checkYodaConditions
-        );
-        $errors = IfConditionHelper::processNodeHelper(
-            $rightType,
-            $leftType,
-            $node,
-            $errors,
-            [],
-            $node,
-            $this->reflectionProvider,
-            false,
-            false
-        );
-
-        $errorsFound = false;
-        $this->checkErrors($node, $leftType, $rightType, $errors, $errorsFound);
-        if ($errorsFound === false) {
-            $this->checkErrors($node, $rightType, $leftType, $errors, $errorsFound);
+        if ($scope->isInTrait()) {
+            return [];
         }
 
-        return $errors;
-    }
-
-    /**
-     * @param Node\Expr\AssignOp $node
-     * @param array<int, \PHPStan\Rules\RuleError> $errors
-     */
-    private function checkErrors(
-        Node\Expr          $node,
-        \PHPStan\Type\Type $type_1,
-        \PHPStan\Type\Type $type_2,
-        array              &$errors,
-        bool               &$errorsFound
-    ): void
-    {
-        if (
-            $type_1->isString()->yes()
-            &&
-            !($type_2 instanceof \PHPStan\Type\MixedType)
-            &&
-            !IfConditionHelper::isPhpStanTypeMaybeWithUnionNullable($type_2, \PHPStan\Type\StringType::class)
-            &&
-            $type_2->describe(VerbosityLevel::typeOnly()) !== 'string' // INFO: hack for non-empty-string
-        ) {
-            if (
-                $node instanceof Node\Expr\AssignOp\Concat
-                &&
-                !IfConditionHelper::hasConstantStringValue($type_1, '')
-                &&
-                !($type_2->toString() instanceof ErrorType)
-            ) {
-                return;
-            }
-
-            $errors[] = IfConditionHelper::buildErrorMessage(
-                $node,
-                sprintf(
-                    'string (%s) in combination with non-string (%s) is not allowed.',
-                    $type_1->describe(VerbosityLevel::value()),
-                    $type_2->describe(VerbosityLevel::value())
-                ),
-                $node->getStartLine()
-            );
-
-            $errorsFound = true;
-
-            return;
-        }
-
-        if (
-            $type_1->isArray()->yes()
-            &&
-            !($type_2 instanceof \PHPStan\Type\MixedType)
-            &&
-            $type_2->isArray()->no()
-        ) {
-            $errors[] = IfConditionHelper::buildErrorMessage(
-                $node,
-                sprintf(
-                    'array (%s) in combination with non-array (%s) is not allowed.',
-                    $type_1->describe(VerbosityLevel::value()),
-                    $type_2->describe(VerbosityLevel::value())
-                ),
-                $node->getStartLine()
-            );
-
-            $errorsFound = true;
-        }
+        return $this->diagnostics->processNode($node, $scope);
     }
 }

--- a/src/voku/PHPStan/Rules/ExtendedAssignOpRuleDiagnostics.php
+++ b/src/voku/PHPStan/Rules/ExtendedAssignOpRuleDiagnostics.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace voku\PHPStan\Rules;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Rules\RuleError;
+use PHPStan\Type\ErrorType;
+use PHPStan\Type\Type;
+use PHPStan\Type\VerbosityLevel;
+use function sprintf;
+
+/**
+ * Shared diagnostic calculation for direct and trait-context ExtendedAssignOpRule analysis.
+ */
+final class ExtendedAssignOpRuleDiagnostics
+{
+    /**
+     * @var bool
+     */
+    private $checkForAssignments;
+
+    /**
+     * @var bool
+     */
+    private $checkYodaConditions;
+
+    /**
+     * @var ReflectionProvider
+     */
+    private $reflectionProvider;
+
+    public function __construct(
+        ReflectionProvider $reflectionProvider,
+        bool $checkForAssignments = false,
+        bool $checkYodaConditions = false
+    ) {
+        $this->reflectionProvider = $reflectionProvider;
+        $this->checkForAssignments = $checkForAssignments;
+        $this->checkYodaConditions = $checkYodaConditions;
+    }
+
+    /**
+     * @return array<int, RuleError>
+     */
+    public function processNode(Node\Expr\AssignOp $node, Scope $scope): array
+    {
+        $errors = [];
+
+        $leftType = $scope->getType($node->var);
+        $rightType = $scope->getType($node->expr);
+
+        $errors = IfConditionHelper::processNodeHelper(
+            $leftType,
+            $rightType,
+            $node,
+            $errors,
+            [],
+            $node,
+            $this->reflectionProvider,
+            $this->checkForAssignments,
+            $this->checkYodaConditions
+        );
+        $errors = IfConditionHelper::processNodeHelper(
+            $rightType,
+            $leftType,
+            $node,
+            $errors,
+            [],
+            $node,
+            $this->reflectionProvider,
+            false,
+            false
+        );
+
+        $errorsFound = false;
+        $this->checkErrors($node, $leftType, $rightType, $errors, $errorsFound);
+        if ($errorsFound === false) {
+            $this->checkErrors($node, $rightType, $leftType, $errors, $errorsFound);
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @param array<int, RuleError> $errors
+     */
+    private function checkErrors(
+        Node\Expr\AssignOp $node,
+        Type $type_1,
+        Type $type_2,
+        array &$errors,
+        bool &$errorsFound
+    ): void {
+        if (
+            $type_1->isString()->yes()
+            &&
+            !($type_2 instanceof \PHPStan\Type\MixedType)
+            &&
+            !IfConditionHelper::isPhpStanTypeMaybeWithUnionNullable($type_2, \PHPStan\Type\StringType::class)
+            &&
+            $type_2->describe(VerbosityLevel::typeOnly()) !== 'string'
+        ) {
+            if (
+                $node instanceof Node\Expr\AssignOp\Concat
+                &&
+                !IfConditionHelper::hasConstantStringValue($type_1, '')
+                &&
+                !($type_2->toString() instanceof ErrorType)
+            ) {
+                return;
+            }
+
+            $errors[] = IfConditionHelper::buildErrorMessage(
+                $node,
+                sprintf(
+                    'string (%s) in combination with non-string (%s) is not allowed.',
+                    $type_1->describe(VerbosityLevel::value()),
+                    $type_2->describe(VerbosityLevel::value())
+                ),
+                $node->getStartLine()
+            );
+
+            $errorsFound = true;
+
+            return;
+        }
+
+        if (
+            $type_1->isArray()->yes()
+            &&
+            !($type_2 instanceof \PHPStan\Type\MixedType)
+            &&
+            $type_2->isArray()->no()
+        ) {
+            $errors[] = IfConditionHelper::buildErrorMessage(
+                $node,
+                sprintf(
+                    'array (%s) in combination with non-array (%s) is not allowed.',
+                    $type_1->describe(VerbosityLevel::value()),
+                    $type_2->describe(VerbosityLevel::value())
+                ),
+                $node->getStartLine()
+            );
+
+            $errorsFound = true;
+        }
+    }
+}

--- a/src/voku/PHPStan/Rules/TraitContextAssignOpCollector.php
+++ b/src/voku/PHPStan/Rules/TraitContextAssignOpCollector.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace voku\PHPStan\Rules;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\AssignOp;
+use PHPStan\Analyser\Scope;
+use PHPStan\Collectors\Collector;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Rules\LineRuleError;
+
+/**
+ * Collects assignment diagnostics for every using-class context of a trait expression.
+ *
+ * @implements Collector<AssignOp, array{
+ *     string,
+ *     string,
+ *     string,
+ *     string,
+ *     array<int, array{string, null|string, int}>
+ * }>
+ */
+final class TraitContextAssignOpCollector implements Collector
+{
+    /**
+     * @var ExtendedAssignOpRuleDiagnostics
+     */
+    private $diagnostics;
+
+    public function __construct(
+        ReflectionProvider $reflectionProvider,
+        bool $checkForAssignments = false,
+        bool $checkYodaConditions = false
+    ) {
+        $this->diagnostics = new ExtendedAssignOpRuleDiagnostics(
+            $reflectionProvider,
+            $checkForAssignments,
+            $checkYodaConditions
+        );
+    }
+
+    public function getNodeType(): string
+    {
+        return AssignOp::class;
+    }
+
+    /**
+     * @param AssignOp $node
+     *
+     * @return array{
+     *     string,
+     *     string,
+     *     string,
+     *     string,
+     *     array<int, array{string, null|string, int}>
+     * }|null
+     */
+    public function processNode(Node $node, Scope $scope)
+    {
+        if (!$scope->isInTrait()) {
+            return null;
+        }
+
+        $traitReflection = $scope->getTraitReflection();
+        $traitFile = $traitReflection->getFileName();
+        if ($traitFile === null) {
+            return null;
+        }
+
+        $classReflection = $scope->getClassReflection();
+        $contextName = $classReflection !== null
+            ? $classReflection->getName()
+            : $scope->getFileDescription();
+
+        $serializedErrors = [];
+        foreach ($this->diagnostics->processNode($node, $scope) as $error) {
+            $serializedErrors[] = [
+                $error->getMessage(),
+                $error instanceof IdentifierRuleError ? $error->getIdentifier() : null,
+                $error instanceof LineRuleError ? $error->getLine() : $node->getStartLine(),
+            ];
+        }
+
+        return [
+            $traitReflection->getName(),
+            $contextName,
+            self::expressionKey($node),
+            $traitFile,
+            $serializedErrors,
+        ];
+    }
+
+    private static function expressionKey(AssignOp $node): string
+    {
+        return \implode(':', [
+            \get_class($node),
+            (string) $node->getStartLine(),
+            (string) $node->getAttribute('startFilePos', -1),
+            (string) $node->getAttribute('endFilePos', -1),
+        ]);
+    }
+}

--- a/src/voku/PHPStan/Rules/TraitContextComparisonRule.php
+++ b/src/voku/PHPStan/Rules/TraitContextComparisonRule.php
@@ -11,7 +11,7 @@ use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 
 /**
- * Publishes only trait comparison diagnostics that are valid in every observed using-class context.
+ * Publishes only trait diagnostics that are valid in every observed using-class context.
  *
  * @implements Rule<CollectedDataNode>
  */
@@ -38,6 +38,32 @@ final class TraitContextComparisonRule implements Rule
         $expressions = [];
 
         foreach ($node->get(TraitContextComparisonCollector::class) as $fileData) {
+            foreach ($fileData as $data) {
+                $traitName = $data[0];
+                $contextName = $data[1];
+                $expressionKey = $data[2];
+                $file = $data[3];
+                $serializedErrors = $data[4];
+
+                if (!isset($expressions[$traitName][$expressionKey])) {
+                    $expressions[$traitName][$expressionKey] = [
+                        'file' => $file,
+                        'contexts' => [],
+                    ];
+                }
+
+                if (!isset($expressions[$traitName][$expressionKey]['contexts'][$contextName])) {
+                    $expressions[$traitName][$expressionKey]['contexts'][$contextName] = [];
+                }
+
+                foreach ($serializedErrors as $serializedError) {
+                    $errorKey = \serialize($serializedError);
+                    $expressions[$traitName][$expressionKey]['contexts'][$contextName][$errorKey] = $serializedError;
+                }
+            }
+        }
+
+        foreach ($node->get(TraitContextAssignOpCollector::class) as $fileData) {
             foreach ($fileData as $data) {
                 $traitName = $data[0];
                 $contextName = $data[1];

--- a/tests/RulesNeonRegistrationTest.php
+++ b/tests/RulesNeonRegistrationTest.php
@@ -20,6 +20,7 @@ use voku\PHPStan\Rules\IfConditionRule;
 use voku\PHPStan\Rules\IfConditionSwitchCaseRule;
 use voku\PHPStan\Rules\IfConditionTernaryOperatorRule;
 use voku\PHPStan\Rules\InArrayLooseComparisonRule;
+use voku\PHPStan\Rules\TraitContextAssignOpCollector;
 use voku\PHPStan\Rules\TraitContextComparisonCollector;
 use voku\PHPStan\Rules\TraitContextComparisonRule;
 use voku\PHPStan\Rules\WrongCastRule;
@@ -62,6 +63,7 @@ final class RulesNeonRegistrationTest extends PHPStanTestCase
      * @var array<int, class-string<Collector>>
      */
     private const SHIPPED_COLLECTORS = [
+        TraitContextAssignOpCollector::class,
         TraitContextComparisonCollector::class,
     ];
 

--- a/tests/TraitContextAssignOpIntegrationTest.php
+++ b/tests/TraitContextAssignOpIntegrationTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace voku\PHPStan\Rules\Test;
+
+use PHPStan\Analyser\Analyser;
+use PHPStan\Analyser\AnalyserResultFinalizer;
+use PHPStan\Analyser\Error;
+use PHPStan\File\FileHelper;
+use PHPStan\Testing\PHPStanTestCase;
+
+/**
+ * End-to-end proof that ExtendedAssignOpRule uses the same trait-context publication boundary.
+ */
+final class TraitContextAssignOpIntegrationTest extends PHPStanTestCase
+{
+    private const TRAIT_FIXTURE = __DIR__ . '/fixtures/TraitContext/AssignOpTrait.php';
+    private const STRING_CONSUMER_ONE_FIXTURE = __DIR__ . '/fixtures/TraitContext/StringAssignTraitConsumerOne.php';
+    private const STRING_CONSUMER_TWO_FIXTURE = __DIR__ . '/fixtures/TraitContext/StringAssignTraitConsumerTwo.php';
+    private const INT_CONSUMER_FIXTURE = __DIR__ . '/fixtures/TraitContext/IntAssignTraitConsumer.php';
+    private const TRAIT_ASSIGN_LINE = 11;
+    private const EXTENDED_ASSIGN_MESSAGE = 'in combination with non-string (1) is not allowed.';
+
+    /**
+     * @return array<int, string>
+     */
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [
+            \dirname(__DIR__) . '/rules.neon',
+        ];
+    }
+
+    public function testSingleStringConsumerKeepsAssignTraitDiagnostic(): void
+    {
+        $errors = $this->vokuErrors($this->runAnalyse([
+            self::TRAIT_FIXTURE,
+            self::STRING_CONSUMER_ONE_FIXTURE,
+        ]));
+
+        self::assertMessageCount($errors, self::EXTENDED_ASSIGN_MESSAGE, 1);
+        self::assertTraitSourceForMatchingErrors($errors, self::EXTENDED_ASSIGN_MESSAGE);
+    }
+
+    public function testEquivalentStringConsumersPublishAssignTraitDiagnosticOnce(): void
+    {
+        $errors = $this->vokuErrors($this->runAnalyse([
+            self::TRAIT_FIXTURE,
+            self::STRING_CONSUMER_ONE_FIXTURE,
+            self::STRING_CONSUMER_TWO_FIXTURE,
+        ]));
+
+        self::assertMessageCount($errors, self::EXTENDED_ASSIGN_MESSAGE, 1);
+        self::assertTraitSourceForMatchingErrors($errors, self::EXTENDED_ASSIGN_MESSAGE);
+    }
+
+    public function testDifferentAssignContextsDoNotPublishContextSpecificDiagnostic(): void
+    {
+        $errors = $this->vokuErrors($this->runAnalyse([
+            self::TRAIT_FIXTURE,
+            self::STRING_CONSUMER_ONE_FIXTURE,
+            self::INT_CONSUMER_FIXTURE,
+        ]));
+
+        self::assertMessageCount($errors, self::EXTENDED_ASSIGN_MESSAGE, 0);
+    }
+
+    /**
+     * @param array<int, string> $files
+     *
+     * @return array<int, Error>
+     */
+    private function runAnalyse(array $files): array
+    {
+        /** @var FileHelper $fileHelper */
+        $fileHelper = self::getContainer()->getByType(FileHelper::class);
+        foreach ($files as $index => $file) {
+            $files[$index] = $fileHelper->normalizePath($file);
+        }
+
+        /** @var Analyser $analyser */
+        $analyser = self::getContainer()->getByType(Analyser::class);
+        /** @var AnalyserResultFinalizer $finalizer */
+        $finalizer = self::getContainer()->getByType(AnalyserResultFinalizer::class);
+
+        return $finalizer->finalize(
+            $analyser->analyse($files, null, null, true),
+            false,
+            true
+        )->getErrors();
+    }
+
+    /**
+     * @param array<int, Error> $errors
+     *
+     * @return array<int, Error>
+     */
+    private function vokuErrors(array $errors): array
+    {
+        return \array_values(\array_filter(
+            $errors,
+            static function (Error $error): bool {
+                $identifier = $error->getIdentifier();
+
+                return $identifier !== null && \strpos($identifier, 'voku.') === 0;
+            }
+        ));
+    }
+
+    /**
+     * @param array<int, Error> $errors
+     */
+    private static function assertMessageCount(array $errors, string $needle, int $expectedCount): void
+    {
+        $count = 0;
+        foreach ($errors as $error) {
+            if (\strpos($error->getMessage(), $needle) !== false) {
+                ++$count;
+            }
+        }
+
+        static::assertSame($expectedCount, $count, 'Unexpected diagnostic count for: ' . $needle);
+    }
+
+    /**
+     * @param array<int, Error> $errors
+     */
+    private static function assertTraitSourceForMatchingErrors(array $errors, string $needle): void
+    {
+        $matched = false;
+
+        foreach ($errors as $error) {
+            if (\strpos($error->getMessage(), $needle) === false) {
+                continue;
+            }
+
+            $matched = true;
+            static::assertSame(self::TRAIT_ASSIGN_LINE, $error->getLine());
+            static::assertSame('AssignOpTrait.php', \basename($error->getFilePath()));
+        }
+
+        static::assertTrue($matched, 'Expected at least one trait diagnostic containing: ' . $needle);
+    }
+}

--- a/tests/fixtures/TraitContext/AssignOpTrait.php
+++ b/tests/fixtures/TraitContext/AssignOpTrait.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace voku\PHPStan\Rules\Test\fixtures\TraitContext;
+
+trait AssignOpTrait
+{
+    public function mutateValue(): void
+    {
+        $this->value += 1;
+    }
+}

--- a/tests/fixtures/TraitContext/IntAssignTraitConsumer.php
+++ b/tests/fixtures/TraitContext/IntAssignTraitConsumer.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace voku\PHPStan\Rules\Test\fixtures\TraitContext;
+
+final class IntAssignTraitConsumer
+{
+    use AssignOpTrait;
+
+    /** @var int */
+    private $value = 1;
+}

--- a/tests/fixtures/TraitContext/StringAssignTraitConsumerOne.php
+++ b/tests/fixtures/TraitContext/StringAssignTraitConsumerOne.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace voku\PHPStan\Rules\Test\fixtures\TraitContext;
+
+final class StringAssignTraitConsumerOne
+{
+    use AssignOpTrait;
+
+    /** @var string */
+    private $value = 'value';
+}

--- a/tests/fixtures/TraitContext/StringAssignTraitConsumerTwo.php
+++ b/tests/fixtures/TraitContext/StringAssignTraitConsumerTwo.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace voku\PHPStan\Rules\Test\fixtures\TraitContext;
+
+final class StringAssignTraitConsumerTwo
+{
+    use AssignOpTrait;
+
+    /** @var string */
+    private $value = 'other';
+}


### PR DESCRIPTION
## Summary

Completes the remaining trait-context operator gap called out in #79, this time with a dedicated `ExtendedAssignOpRule` reproduction rather than assumption.

- extract the existing `ExtendedAssignOpRule` diagnostic calculation without changing its direct non-trait behavior;
- suppress direct assign-op publication while PHPStan is analysing a trait body;
- add a node-specific `TraitContextAssignOpCollector` and feed it into the existing trait-context publication rule;
- register the collector through `rules.neon` and the real-container registration test;
- add a trait fixture using `+= 1` with two string consumers and one int consumer;
- prove one string context => one trait-source finding, two equivalent string contexts => still one, and string+int contexts => the context-specific finding is suppressed.

The public `ExtendedAssignOpRule` constructor is unchanged.

## Scope

This completes the `ExtendedBinaryOpRule` / `ExtendedAssignOpRule` trait-deferral gap from #79. The supported PHPStan range remains a separate, pre-existing decision and is not changed here.

Part of #79.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved assignment-operation diagnostics when code is used within traits.
  * Diagnostics now account for each consuming class context and avoid duplicate reports.
  * Preserved valid mixed-type scenarios while detecting incompatible string and array assignments.

* **Tests**
  * Added integration coverage for trait-based assignment checks, including shared and differing consumer contexts.
  * Verified the new collector is registered and loaded correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->