### PR TITLE
Make the supported PHPStan floor explicit and tested

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Install dependencies
         run: |
           if [[ "${{ matrix.php }}" == "7.4" ]]; then
-            composer require phpstan/phpstan --no-update
+            composer require phpstan/phpstan:2.1.56 --no-update
           fi;
 
           if [[ "${{ matrix.composer }}" == "basic" ]]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ### Upcoming
+- raise the supported PHPStan floor to 2.1.56 and exercise that exact lower bound in CI
 - restore clean self-analysis for the comparison policy, make PHPStan analysis blocking in CI, and propagate duplicate-native suppression through ternary, match, switch and boolean condition rules
 - propagate `checkYodaConditions` to ternary, match and switch rules, and fix definite array/non-array checks in binary and assignment operators
 - add opt-in `InArrayLooseComparisonRule` for PHP 7/8 loose-comparison surprises in `in_array()` and `array_search()`

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     },
     "require": {
         "php": "^7.4 || ^8.0",
-        "phpstan/phpstan": "~2.0"
+        "phpstan/phpstan": "^2.1.56"
     },
     "require-dev": {
         "phpstan/phpstan-phpunit": "~2.0",


### PR DESCRIPTION
Superseded by #84.

This PR started before #82 merged, so its PHPStan 2.1.56 lower-bound run did not exercise the final trait-collector tree. #84 reapplies the same three-file contract change on top of the post-#82 `master` and is the authoritative compatibility check.