### PR TITLE
Make the supported PHPStan floor explicit and tested

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Install dependencies
         run: |
           if [[ "${{ matrix.php }}" == "7.4" ]]; then
-            composer require phpstan/phpstan --no-update
+            composer require phpstan/phpstan:2.1.56 --no-update
           fi;
 
           if [[ "${{ matrix.composer }}" == "basic" ]]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ### Upcoming
+- raise the supported PHPStan floor to 2.1.56 and exercise that exact lower bound in CI
 - restore clean self-analysis for the comparison policy, make PHPStan analysis blocking in CI, and propagate duplicate-native suppression through ternary, match, switch and boolean condition rules
 - propagate `checkYodaConditions` to ternary, match and switch rules, and fix definite array/non-array checks in binary and assignment operators
 - add opt-in `InArrayLooseComparisonRule` for PHP 7/8 loose-comparison surprises in `in_array()` and `array_search()`

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     },
     "require": {
         "php": "^7.4 || ^8.0",
-        "phpstan/phpstan": "~2.0"
+        "phpstan/phpstan": "^2.1.56"
     },
     "require-dev": {
         "phpstan/phpstan-phpunit": "~2.0",


### PR DESCRIPTION
## Summary

Resolves the pre-existing support-range mismatch documented in #79 on top of the complete post-#82 tree.

- raise `phpstan/phpstan` from `~2.0` to `^2.1.56`;
- pin the PHP 7.4 CI lane to exactly PHPStan 2.1.56, so the lower bound is exercised continuously against the final trait-collector implementation;
- keep the PHP 8.0–8.4 lanes on current compatible PHPStan;
- keep blocking self-analysis on PHP 8.4/current PHPStan;
- document the new floor in the Upcoming changelog.

This deliberately chooses the smaller honest contract over maintaining version-specific expected-message forks for PHPStan 2.0.x / early 2.1.x. #79 established that 2.1.56 and 2.2.9 are green while 2.0.0 and 2.1.0 fail on pre-existing inference differences.

Supersedes #83, which started before #82 merged and therefore did not exercise the final tree.

Part of #79.